### PR TITLE
sizeof(pointer) fixes

### DIFF
--- a/bpv7/utils/bptrace.c
+++ b/bpv7/utils/bptrace.c
@@ -102,7 +102,7 @@ void print(statusReport *rpt){
 		printf("%u/%u ", rpt->creationCount, rpt->fragmentOffset);
 	char* buffer = malloc(32);
 	printf("%8s at %s on %s, '%s'.\n", 
-		statusToString(rpt->statusFlags, buffer, sizeof(buffer)), tmbuffer, rpt->bundleSourceEid,
+		statusToString(rpt->statusFlags, buffer, 32), tmbuffer, rpt->bundleSourceEid,
 		rpt->reasonString);
 	free(buffer);
 	printDBG(3, "statusTime: " UVAST_FIELDSPEC "<=> %s\n", rpt->statusTime, tmbuffer);

--- a/ici/library/platform_sm.c
+++ b/ici/library/platform_sm.c
@@ -1055,7 +1055,7 @@ static SemaphoreTable	*_semTbl(int action)
 
 		default:		/*	New SemaphoreTable.	*/
 			memset((char *) semaphoreTable, 0,
-					sizeof(semaphoreTable));
+					sizeof(SemaphoreTable));
 		}
 	}
 

--- a/tc/dtka/dtka.c
+++ b/tc/dtka/dtka.c
@@ -175,6 +175,7 @@ int generateHMACKey(int keysize, unsigned char *buf)
 	return result;
 }
 
+/* buf and private_buf should be at least keysize bytes in size */
 int generateECDSAKey(int keysize, unsigned char *buf, unsigned char *private_buf)
 {
 	mbedtls_ecdsa_context ecdsa_context;
@@ -209,8 +210,8 @@ int generateECDSAKey(int keysize, unsigned char *buf, unsigned char *private_buf
 
 	// Extract keys from context
 	mbedtls_ecp_point_write_binary(&ecdsa_context.grp, &ecdsa_context.Q,
-								   MBEDTLS_ECP_PF_UNCOMPRESSED, &len, buf, sizeof(buf));
-	mbedtls_ecp_write_key(&ecdsa_context, private_buf, sizeof(private_buf));
+								   MBEDTLS_ECP_PF_UNCOMPRESSED, &len, buf, keysize);
+	mbedtls_ecp_write_key(&ecdsa_context, private_buf, keysize);
 
 	mbedtls_entropy_free(&entropy);
 	mbedtls_ctr_drbg_free(&ctr_drbg);
@@ -231,10 +232,10 @@ static int generateKeyPair(BpSAP sap, DtkaDB *db, char *keyType, int keySize)
 #else /*	For regression testing only.			*/
 	int key;
 #endif
-	unsigned char *pubKeyBuf = malloc(sizeof(unsigned char) * keySize);
+	unsigned char *pubKeyBuf = malloc(keySize);
 	unsigned short publicKeyLen;
 	unsigned char *publicKey;
-	unsigned char *privKeyBuf = malloc(sizeof(unsigned char) * keySize);
+	unsigned char *privKeyBuf = malloc(keySize);
 	unsigned short privateKeyLen;
 	unsigned char *privateKey;
 	char recordBuffer[TC_MAX_REC];
@@ -274,7 +275,7 @@ static int generateKeyPair(BpSAP sap, DtkaDB *db, char *keyType, int keySize)
 	}
 
 	publicKeyLen = keySize;
-	publicKey = (pubKeyBuf + (sizeof pubKeyBuf - 1)) - publicKeyLen;
+	publicKey = pubKeyBuf;
 
 	if (strcmp(keyType, "ecdsa") != 0)
 	{
@@ -283,7 +284,7 @@ static int generateKeyPair(BpSAP sap, DtkaDB *db, char *keyType, int keySize)
 	}
 
 	privateKeyLen = keySize;
-	privateKey = (privKeyBuf + (sizeof privKeyBuf - 1)) - privateKeyLen;
+	privateKey = privKeyBuf;
 
 	sdr_exit_xn(sdr);
 #else /*	For regression testing only.			*/

--- a/tc/dtka/dtkaadmin.c
+++ b/tc/dtka/dtkaadmin.c
@@ -125,7 +125,7 @@ static void managekeyType(int tokenCount, char **tokens)
 
 	CHKVOID(sdr_begin_xn(sdr));
 	sdr_stage(sdr, (char *)&dtkadb, dtkadbObj, sizeof(DtkaDB));
-	istrcpy(dtkadb.keyType, newkeyType, sizeof(newkeyType));
+	istrcpy(dtkadb.keyType, newkeyType, sizeof(dtkadb.keyType));
 	dtkadb.keySize = newkeySize;
 	sdr_write(sdr, dtkadbObj, (char *)&dtkadb, sizeof(DtkaDB));
 	if (sdr_end_xn(sdr) < 0)


### PR DESCRIPTION
Fixes issues related to incorrect use of sizeof.

Not exactly sure of the the intended purpose of the line:

```
privateKey = (privKeyBuf + (sizeof privKeyBuf - 1)) - privateKeyLen;
```

There's no way this was correct, as it would run off the beginning of the privKeyBuf (sizeof privKeyBuf would evaluate to 4 or 8 depending on the size of pointers).