### PR TITLE
Fix memory safety and type mismatch bugs (#63, #65, #66)

### DIFF
--- a/ams/library/libams.c
+++ b/ams/library/libams.c
@@ -1115,7 +1115,7 @@ static int	constructMessage(AmsSAP *sap, short subjectNbr, int priority,
 	|| subject->symmetricKeyName == NULL)	/*	no encryption	*/
 	{
 
-		MRELEASE(content);
+		MRELEASE(*content);
 		*content = newContent;
 		*contentLength = newContentLength;
 

--- a/bpv7/ipn/ipnfw.c
+++ b/bpv7/ipn/ipnfw.c
@@ -194,7 +194,7 @@ static int	initializeHIRR(CgrRtgObject *routingObj)
 		{
 			/*	Node is a passageway.			*/
 
-			if (sdr_list_insert_last(sdr,
+			if (sm_list_insert_last(ionwm,
 					routingObj->viaPassageways,
 					member->fqnn) == 0)
 			{

--- a/tc/dtka/dtkaadmin.c
+++ b/tc/dtka/dtkaadmin.c
@@ -206,7 +206,6 @@ static void manageLeadTime(int tokenCount, char **tokens)
 	Object dtkadbObj = getDtkaDbObject();
 	DtkaDB dtkadb;
 	int newLeadTime;
-	char test[5];
 
 	if (tokenCount != 3)
 	{
@@ -229,7 +228,6 @@ static void manageLeadTime(int tokenCount, char **tokens)
 	{
 		putErrmsg("Can't change leadtime.", NULL);
 	}
-	sprintf(test, "%u", dtkadb.effectiveLeadTime);
 }
 
 static void executeManage(int tokenCount, char **tokens)


### PR DESCRIPTION
Fixes for three open bugs, all verified against the source. Minimal changes, one fix per file.

---

### `ams/library/libams.c` — fix MRELEASE dereference (#66)

`constructMessage` receives `content` as `char **`. At line 1118, `MRELEASE(content)` frees the stack pointer itself instead of the buffer it points to. Every other MRELEASE call in the same function correctly uses `*content`.

```c
// before (frees the char** pointer — crash or memory leak)
MRELEASE(content);

// after (frees the actual content buffer)
MRELEASE(*content);
```

---

### `tc/dtka/dtkaadmin.c` — remove dead code with buffer overflow risk (#65)

`manageLeadTime` declares `char test[5]` and calls `sprintf(test, "%u", ...)` but the result is never read. The buffer is too small for the full range of `unsigned int` (up to 10 digits), and the only input validation is `>= 20`, so any value above 9999 would overflow. Removed both the buffer and the sprintf since they serve no purpose.

---

### `bpv7/ipn/ipnfw.c` — fix SDR/SM list type mismatch (#63)

`initializeHIRR` creates `viaPassageways` with `sm_list_create(ionwm)` (shared memory list), but then tries to populate it using `sdr_list_insert_last` (SDR persistent store function). These are completely different list implementations. Changed to `sm_list_insert_last(ionwm, ...)` to match the list type. This is consistent with how the list is destroyed in `libcgr.c` using `sm_list_destroy`.

---

All three are single-line changes. No functional additions, just correcting existing behavior to match what the code clearly intended.