### PR TITLE
Fix macOS clang build error in sendfile.c

### DIFF
--- a/bpv7/utils/sendfile.c
+++ b/bpv7/utils/sendfile.c
@@ -126,7 +126,7 @@ static int	run_sendfile(char *ownEid, char *destEid, char *fileName,
 
 
 	/*metadata vars*/
-	const int randomizer_size = 21;
+#define RANDOMIZER_SIZE 21
 	uint64_t timestamp = 0;
 	size_t out_contentLength=0;
 	size_t nameSize = 0;
@@ -141,7 +141,7 @@ static int	run_sendfile(char *ownEid, char *destEid, char *fileName,
 	unsigned char versionNumber = 0;
 
 	/*random name and supplemental iv personalizer*/
-	char randInitializer[randomizer_size];
+	char randInitializer[RANDOMIZER_SIZE];
 	char *name = NULL;
 
 
@@ -493,7 +493,7 @@ exit:
 	memset(destEid, 0, strlen(destEid));
 	destEid = NULL;
 
-	memset(randInitializer, 0, randomizer_size);
+	memset(randInitializer, 0, RANDOMIZER_SIZE);
 	memset(progressText, 0, 300);
 
 	/*ION specific*/


### PR DESCRIPTION
This fixes the build error on macOS with recent clang versions (issue #56).

The problem is that const int is not a compile-time constant in C, only in C++. When used as an array size, clang treats it as a variable-length array and warns about it with -Wgnu-folding-constant. Since the project uses -Werror, this becomes a build failure.

The fix is simple: replace const int with #define, which is the standard way to define array sizes in C.

Error message before fix:
bpv7/utils/sendfile.c:100:23: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]

Tested with gcc -std=c99 -Wall -Werror, compiles clean.