### PR TITLE
Improve AMS performance & benchmarking: semaphore fast-path, checksum, bench stats

### DIFF
--- a/ams/library/amscommon.c
+++ b/ams/library/amscommon.c
@@ -781,20 +781,17 @@ unsigned short	computeAmsChecksum(unsigned char *cursor, int pduLength)
 	unsigned int	sum = 0;
 	unsigned short	addend;
 
-	while (pduLength > 0)
+	while (pduLength >= 2)
 	{
-		addend = *cursor;
-		addend <<= 8;	/*	Low-order byte is now zero pad.	*/
-		cursor++;
-		pduLength--;
-		if (pduLength > 0)	/*	Replace pad with byte.	*/
-		{
-			addend += *cursor;
-			cursor++;
-			pduLength--;
-		}
+		addend = (cursor[0] << 8) + cursor[1];
+		cursor += 2;
+		pduLength -= 2;
+		sum += addend;
+	}
 
-		sum += addend;		/*	Okay if it overflows.	*/
+	if (pduLength > 0)
+	{
+		sum += cursor[0] << 8;
 	}
 
 	return sum & 0x0000ffff;

--- a/ams/library/amsd.c
+++ b/ams/library/amsd.c
@@ -936,6 +936,10 @@ static void	processHeartbeatCycle(RsState *rsState, int *cycleCount,
 		if (rsState->csEndpoint != NULL || rsState->cellHeartbeats > 0)
 		{
 			rsState->cellHeartbeats++;
+			if (rsState->cellHeartbeats == N6_COUNT + 1)
+			{
+				writeMemo("[i] Registrar cell census completed.");
+			}
 		}
 
 		/*	Send heartbeats to all modules in own cell.	*/

--- a/ams/library/libams.c
+++ b/ams/library/libams.c
@@ -646,9 +646,6 @@ static int	recoverMsgContent(AmsSAP *sap, AmsMsg *msg, Subject *subject)
 	char		*newContent = NULL;
 	int			newContentLength = 0;
 	UnmarshalFn	unmarshal = NULL;
-	char		keyBuffer[512] = {0};
-	int			keyBufferLength = sizeof keyBuffer;
-	int			keyLength = 0;
 
 	/*	Decrypt content as necessary.				*/
 
@@ -670,6 +667,11 @@ static int	recoverMsgContent(AmsSAP *sap, AmsMsg *msg, Subject *subject)
 	}
 	else
 	{
+		char	keyBuffer[512];
+		int	keyBufferLength = sizeof keyBuffer;
+		int	keyLength;
+
+		memset(keyBuffer, 0, sizeof keyBuffer);
 		keyLength = sec_get_key(subject->symmetricKeyName,
 				&keyBufferLength, keyBuffer);
 		if (keyLength <= 0)

--- a/ams/test/amsbenchr.c
+++ b/ams/test/amsbenchr.c
@@ -6,12 +6,30 @@
 			The first 4 bytes of each message contain the
 			total number of messages that will be published,
 			including this one.
-									*/
+								*/
 /*	Copyright (c) 2005, California Institute of Technology.		*/
 /*	All rights reserved.						*/
 /*	Author: Scott Burleigh, Jet Propulsion Laboratory		*/
 
 #include "ams.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int	compare_double(const void *a, const void *b)
+{
+	double	da = *(const double *) a;
+	double	db = *(const double *) b;
+
+	if (da < db) return -1;
+	if (da > db) return 1;
+	return 0;
+}
+
+static double	tvdiff_usec(struct timeval *start, struct timeval *end)
+{
+	return (double)(end->tv_sec - start->tv_sec) * 1000000.0
+		+ (double)(end->tv_usec - start->tv_usec);
+}
 
 #if defined (ION_LWT)
 int	amsbenchr(saddr a1, saddr a2, saddr a3, saddr a4, saddr a5,
@@ -34,12 +52,24 @@ int	main(void)
 	double		bytes = 0.0;
 	struct timeval	startTime;
 	struct timeval	endTime;
+	struct timeval	prevTime;
+	struct timeval	nowTime;
 	double		usecElapsed;
 	double		seconds;
 	double		msgsPerSec;
 	double		bytesPerSec;
 	double		Mbps;
-	char		buf[128];
+	char		buf[256];
+
+	/*	Per-message timing arrays (allocated after first msg).	*/
+
+	double		*iatUsec = NULL;	/*	Inter-arrival times.	*/
+	int		*recvOrder = NULL;	/*	Message numbers.	*/
+	int		capacity = 0;
+	int		outOfOrder = 0;
+	int		prevMsgNbr = -1;
+	int		minLen = 0;
+	int		maxLen = 0;
 
 	if (ams_register("", NULL, "amsdemo", "test", "", "benchr", &me) < 0)
 	{
@@ -76,8 +106,6 @@ int	main(void)
 			memcpy((char *) &msgNbr, txt, sizeof(int));
 			msgNbr = ntohl(msgNbr);
 
-			/*	Messages arrive in reverse nbr order.	*/
-
 			if (msgNbr < 1)
 			{
 				writeMemoNote("Message number is < 1",
@@ -88,8 +116,53 @@ int	main(void)
 			if (msgs < 0)		/*	First message.	*/
 			{
 				getCurrentTime(&startTime);
+				prevTime = startTime;
 				msgs = 0;
+
+				/*	Allocate arrays based on first
+				 *	message's msgNbr (= total count).*/
+
+				capacity = msgNbr;
+				iatUsec = (double *) calloc(capacity,
+						sizeof(double));
+				recvOrder = (int *) calloc(capacity,
+						sizeof(int));
+				minLen = len;
+				maxLen = len;
 			}
+
+			getCurrentTime(&nowTime);
+
+			/*	Record inter-arrival time.		*/
+
+			if (iatUsec != NULL && msgs < capacity)
+			{
+				iatUsec[msgs] = tvdiff_usec(&prevTime,
+						&nowTime);
+			}
+
+			prevTime = nowTime;
+
+			/*	Record receive order for reorder check.	*/
+
+			if (recvOrder != NULL && msgs < capacity)
+			{
+				recvOrder[msgs] = msgNbr;
+			}
+
+			/*	Track out-of-order (sender counts down).*/
+
+			if (prevMsgNbr >= 0 && msgNbr > prevMsgNbr)
+			{
+				outOfOrder++;
+			}
+
+			prevMsgNbr = msgNbr;
+
+			/*	Track min/max message size.		*/
+
+			if (len < minLen) minLen = len;
+			if (len > maxLen) maxLen = len;
 
 			bytes += len;
 			msgs += 1;
@@ -103,27 +176,104 @@ int	main(void)
 	}
 
 	getCurrentTime(&endTime);
-	if (endTime.tv_usec < startTime.tv_usec)
-	{
-		endTime.tv_usec += 1000000;
-		startTime.tv_sec -= 1;
-	}
-
-	usecElapsed = (1000000 * (endTime.tv_sec - startTime.tv_sec))
-			+ (endTime.tv_usec - startTime.tv_usec);
-	seconds = usecElapsed / 1000000;
+	usecElapsed = tvdiff_usec(&startTime, &endTime);
+	seconds = usecElapsed / 1000000.0;
 	msgsPerSec = msgs / seconds;
 	bytesPerSec = bytes / seconds;
 	Mbps = (bytesPerSec * 8) / (1024 * 1024);
-	isprintf(buf, sizeof buf, "Received %d messages, a total of %.0f bytes,\
-in %f seconds.", msgs, bytes, seconds);
+
+	/*	Basic throughput stats (original).			*/
+
+	isprintf(buf, sizeof buf,
+		"Received %d messages, a total of %.0f bytes,"
+		"in %f seconds.", msgs, bytes, seconds);
 	PUTS(buf);
-	isprintf(buf, sizeof buf, "%10.3f messages per second.", msgsPerSec);
+	isprintf(buf, sizeof buf,
+		"%10.3f messages per second.", msgsPerSec);
 	PUTS(buf);
-	isprintf(buf, sizeof buf, "%10.3f Mbps.", Mbps);
+	isprintf(buf, sizeof buf,
+		"%10.3f Mbps.", Mbps);
 	PUTS(buf);
+
+	/*	Message size stats.					*/
+
+	isprintf(buf, sizeof buf,
+		"Message size: min=%d  max=%d  avg=%.0f bytes.",
+		minLen, maxLen, msgs > 0 ? bytes / msgs : 0.0);
+	PUTS(buf);
+
+	/*	Ordering stats.						*/
+
+	isprintf(buf, sizeof buf,
+		"Out-of-order: %d of %d messages (%.2f%%).",
+		outOfOrder, msgs,
+		msgs > 0 ? 100.0 * outOfOrder / msgs : 0.0);
+	PUTS(buf);
+
+	/*	Inter-arrival time stats.				*/
+
+	if (iatUsec != NULL && msgs > 1)
+	{
+		double	iatMin;
+		double	iatMax;
+		double	iatSum = 0.0;
+		double	iatMean;
+		double	iatP50;
+		double	iatP95;
+		double	iatP99;
+		double	iatJitterSum = 0.0;
+		double	iatJitter;
+		int	iatCount = msgs - 1;	/*	n-1 intervals.	*/
+		int	i;
+
+		/*	Skip first IAT (includes subscription setup).	*/
+
+		iatMin = iatUsec[1];
+		iatMax = iatUsec[1];
+		for (i = 1; i < msgs && i < capacity; i++)
+		{
+			if (iatUsec[i] < iatMin) iatMin = iatUsec[i];
+			if (iatUsec[i] > iatMax) iatMax = iatUsec[i];
+			iatSum += iatUsec[i];
+			if (i > 1)
+			{
+				double diff = iatUsec[i] - iatUsec[i - 1];
+				if (diff < 0) diff = -diff;
+				iatJitterSum += diff;
+			}
+		}
+
+		iatMean = iatSum / iatCount;
+		iatJitter = (iatCount > 1)
+				? iatJitterSum / (iatCount - 1) : 0.0;
+
+		/*	Sort for percentiles (copy to avoid disturbing
+		 *	order; reuse iatUsec since we're done with it).	*/
+
+		qsort(iatUsec + 1, iatCount, sizeof(double),
+				compare_double);
+		iatP50 = iatUsec[1 + iatCount / 2];
+		iatP95 = iatUsec[1 + (int)(iatCount * 0.95)];
+		iatP99 = iatUsec[1 + (int)(iatCount * 0.99)];
+
+		isprintf(buf, sizeof buf,
+			"Inter-arrival (us): "
+			"min=%.0f  max=%.0f  avg=%.0f  "
+			"p50=%.0f  p95=%.0f  p99=%.0f",
+			iatMin, iatMax, iatMean,
+			iatP50, iatP95, iatP99);
+		PUTS(buf);
+		isprintf(buf, sizeof buf,
+			"Mean jitter (us): %.1f", iatJitter);
+		PUTS(buf);
+	}
+
 	fflush(stdout);
 	writeErrmsgMemos();
+
+	if (iatUsec != NULL) free(iatUsec);
+	if (recvOrder != NULL) free(recvOrder);
+
 	ams_unregister(me);
 	return 0;
 }

--- a/ams/test/amsbenchs.c
+++ b/ams/test/amsbenchs.c
@@ -10,6 +10,7 @@
 /*	Author: Scott Burleigh, Jet Propulsion Laboratory		*/
 /*									*/
 #include "ams.h"
+#include <stdlib.h>
 
 static void	reportError(void *userData, AmsEvent *event)
 {
@@ -36,21 +37,32 @@ int	amsbenchs(saddr a1, saddr a2, saddr a3, saddr a4, saddr a5,
 {
 	int		count = a1;
 	int		size = a2;
+	int		minSize = a3 ? a3 : 0;
 #else
 int	main(int argc, char **argv)
 {
 	int		count = (argc > 1 ? atoi(argv[1]) : 0);
 	int		size = (argc > 2 ? atoi(argv[2]) : 0);
+	int		minSize = (argc > 3 ? atoi(argv[3]) : 0);
 #endif
 	char		*buffer;
 	AmsModule	me;
 	AmsEventMgt	rules;
 	short		subjectNbr;
 	int		content;
+	int		msgSize;
+	unsigned int	rngState;
 
 	if (count < 1 || (size < 0 || (size_t)size < sizeof(int)) || size > 65535)
 	{
-		PUTS("Usage: amsbenchs <# of msgs to send> <msg length>");
+		PUTS("Usage: amsbenchs <# of msgs> <max length> [<min length>]");
+		fflush(stdout);
+		return 0;
+	}
+
+	if (minSize > 0 && ((size_t)minSize < sizeof(int) || minSize > size))
+	{
+		PUTS("Min length must be >= 4 and <= max length.");
 		fflush(stdout);
 		return 0;
 	}
@@ -94,12 +106,23 @@ int	main(int argc, char **argv)
 		return -1;
 	}
 
+	rngState = (unsigned int) time(NULL);
 	snooze(1);	/*	Wait for subscriptions to arrive.	*/
 	while (count > 0)
 	{
 		content = htonl(count);
 		memcpy(buffer, (char *) &content, sizeof(int));
-		if (ams_publish(me, subjectNbr, 0, 0, size, buffer, 0) < 0)
+		if (minSize > 0 && minSize < size)
+		{
+			msgSize = minSize + (int)(rand_r(&rngState)
+					% (size - minSize + 1));
+		}
+		else
+		{
+			msgSize = size;
+		}
+
+		if (ams_publish(me, subjectNbr, 0, 0, msgSize, buffer, 0) < 0)
 		{
 			putErrmsg("amsbenchs can't publish message.", NULL);
 			break;

--- a/demos/bench-ams/bench_helpers
+++ b/demos/bench-ams/bench_helpers
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Shared helper functions for AMS bench scripts.
+
+# Wait for a specific string to appear in a log file.
+# Usage: wait_for_log_event <logfile> <pattern> [timeout] [label]
+#   logfile  - path to the log file to monitor
+#   pattern  - grep pattern to wait for
+#   timeout  - seconds to wait before giving up (default: 30)
+#   label    - human-readable label for status messages (default: pattern)
+# Returns 0 on success, 1 on timeout.
+wait_for_log_event() {
+    local logfile=$1
+    local pattern=$2
+    local timeout=${3:-30}
+    local label=${4:-$pattern}
+
+    echo "Waiting for ${label}..."
+    local count=0
+    while [ $count -lt "$timeout" ]; do
+        if grep -q "$pattern" "$logfile" 2>/dev/null; then
+            echo "${label} - done."
+            return 0
+        fi
+        sleep 1
+        count=$((count + 1))
+    done
+    echo "WARNING: ${label} timeout after ${timeout}s, proceeding anyway."
+    return 1
+}

--- a/demos/bench-ams/dotest
+++ b/demos/bench-ams/dotest
@@ -5,7 +5,8 @@ trap 'killm f' EXIT
 
 # Benchtest variables-------------------------------------------------
 COUNT=1000
-MESSAGE_SIZE=1000
+MESSAGE_SIZE_MIN=1000
+MESSAGE_SIZE_MAX=1000
 
 
 # Shut down routine---------------------------------------------------
@@ -94,7 +95,7 @@ fi
 
 cd ../node2
 echo -e "Starting amsbench sender:"
-amsbenchs $COUNT $MESSAGE_SIZE 2>/dev/null &
+amsbenchs $COUNT $MESSAGE_SIZE_MAX $MESSAGE_SIZE_MIN 2>/dev/null &
 sleep 3
 
 # Wait for the receiver to finish or timeout -------------------------

--- a/demos/bench-ams/node2/ionstart
+++ b/demos/bench-ams/node2/ionstart
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/../bench_helpers"
 
 echo > ion.log
 echo -e "\nStarting ION Node 2 on localhost"
@@ -17,13 +18,8 @@ bpadmin		bench.bprc
 #start ams daemon as config server and registrar
 amsd mib.amsrc 127.0.0.1:2502 amsdemo test "" &
 
-#observe the MANDATORY cell census period here!!!
-echo "Waiting for AMS cell census (9 seconds left)..."
-sleep 3
-echo "Waiting for AMS cell census (6 seconds left)..."
-sleep 3
-echo "Waiting for AMS cell census (3 seconds left)..."
-sleep 3
+#wait for registrar cell census to complete
+wait_for_log_event ion.log "cell census completed" 30 "AMS cell census"
 
 #start ramsgate daemon
 ramsgate amsdemo test 300 &

--- a/demos/bench-ams/node3/ionstart
+++ b/demos/bench-ams/node3/ionstart
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/../bench_helpers"
 
 echo > ion.log
 echo -e "\nStarting ION Node 3 on localhost"
@@ -17,13 +18,8 @@ bpadmin		bench.bprc
 #start ams daemon as config server and registrar
 amsd mib.amsrc 127.0.0.1:2503 amsdemo test "" &
 
-#observe the MANDATORY cell census period here!!!
-echo "Waiting for AMS cell census (9 seconds left)..."
-sleep 3
-echo "Waiting for AMS cell census (6 seconds left)..."
-sleep 3
-echo "Waiting for AMS cell census (3 seconds left)..."
-sleep 3
+#wait for registrar cell census to complete
+wait_for_log_event ion.log "cell census completed" 30 "AMS cell census"
 
 #start ramsgate daemon
 ramsgate amsdemo test 300 &

--- a/ici/library/platform_sm.c
+++ b/ici/library/platform_sm.c
@@ -2903,11 +2903,13 @@ typedef struct {
 } SmProcessSemtable;
 
 
-static SmProcessSemtable *_semTbl(int action);
+static inline SmProcessSemtable *_semTbl(int action);
 static SmGlobalSemtable	*_sembase(int action);
 static sem_t *_ipcSemaphore(int action);
 static void _semEraseNamedSems(void);
-static SmLocalSem *_semGetSem(SmProcessSemtable *psemtable, sm_SemId semnum, int semlocked);
+static inline SmLocalSem *_semGetSem(SmProcessSemtable *psemtable, sm_SemId semnum, int semlocked);
+static int __attribute__((noinline)) _semSyncOutOfDate(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked);
+static inline int _semSync(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked);
 static char *_semGenPosixSemname(char *namebuf, unsigned bufsize, int semnum);
 static int _semKeyExists(int key);
 static void _sm_SemCompleteDeletePosix(SmProcessSemtable *semTbl, sm_SemId i);
@@ -2989,9 +2991,9 @@ static int _semKeyExists(int key) {
 }
 
 
-/* ensure that the process local and shared global semaphores are in sync */
-/* N.B.: assumes global semaphore table semaphore is NOT held (unless semlocked is true) */
-static int _semSync(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked)
+/* slow path for _semSync: handles sem_open, close, IPC locking */
+static int __attribute__((noinline))
+_semSyncOutOfDate(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked)
 {
 	char sem_name[MAX_NAMED_SEM_KEYLENGTH];
 	sem_t *psem;
@@ -2999,13 +3001,6 @@ static int _semSync(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked)
 
 	SmLocalSem  *plocalSem = &plocal->lsemtable[semnum];
 	SmGlobalSem *pglobalSem = plocalSem->semgl;
-
-	if (plocalSem->lseq == (smSequence)ion_ipc_atomic_get(&pglobalSem->gseq)) {
-		/* local copy is up to date */
-		return(1);
-	}
-
-	/* above is the expected case, and it needs to be fast... */
 
 	if (!semlocked)
 		takeIpcLock();  /* lock global table across ALL Ion instances */
@@ -3055,8 +3050,23 @@ static int _semSync(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked)
 	return(1);
 }
 
+/* ensure that the process local and shared global semaphores are in sync */
+/* N.B.: assumes global semaphore table semaphore is NOT held (unless semlocked is true) */
+static inline int _semSync(SmProcessSemtable *plocal, sm_SemId semnum, int semlocked)
+{
+	SmLocalSem  *plocalSem = &plocal->lsemtable[semnum];
 
-static SmProcessSemtable *_semTbl(int action)
+	if (__builtin_expect(plocalSem->lseq
+			== (smSequence)ion_ipc_atomic_get(&plocalSem->semgl->gseq), 1)) {
+		/* local copy is up to date (fast path) */
+		return(1);
+	}
+
+	return _semSyncOutOfDate(plocal, semnum, semlocked);
+}
+
+
+static inline SmProcessSemtable *_semTbl(int action)
 {
 	static SmProcessSemtable semStruct;  /* local to each (new) process running Ion */
 	static int	semTableInitialized = 0;
@@ -3118,7 +3128,7 @@ static SmProcessSemtable *_semTbl(int action)
 
 /* return the Local semaphore structure that goes with ION semaphore number "semnum" */
 /* N.B. Assumes that global semaphore is NOT held (unless semlocked is true) */
-static SmLocalSem *_semGetSem(SmProcessSemtable *psemtable, sm_SemId semnum, int semlocked)
+static inline SmLocalSem *_semGetSem(SmProcessSemtable *psemtable, sm_SemId semnum, int semlocked)
 {
 	SmLocalSem *psemLocal;
 


### PR DESCRIPTION
- Inline semaphore hot path (_semTbl, _semGetSem, _semSync) and split _semSync into inline fast-path + noinline slow-path to avoid function call overhead on the common (seq-match) case
- Optimize computeAmsChecksum to process 2 bytes per iteration instead of one-at-a-time with branch
- Defer keyBuffer initialization in recoverMsgContent to the branch that actually uses it
- Add cell census log event in amsd to enable event-driven startup instead of fixed sleep (speedup benchmark)
- Enhance amsbenchr with per-message inter-arrival timing, percentile stats (p50/p95/p99), jitter, out-of-order detection, and min/max/avg message size reporting
- Add variable message size support to amsbenchs (min/max range)
- Extract wait_for_log_event helper (bench_helpers) and refactor ionstart scripts to wait for census log event instead of fixed 9s sleep
- Update dotest to use MESSAGE_SIZE_MIN/MAX variables

Note: some changes were developed with the help of AI (claude code), especially the amsbenchr.* changes. I double checked execution time: instructions and per function cost in kcachegrind. ETA enhancement of possible throughput (or reduction in cpu time) for continious flow of messages around 20-30%.

Benchmark results:
Received 1000 messages, a total of 1000000 bytes,in 0.310885 seconds.
  3216.624 messages per second.
    24.541 Mbps.
Message size: min=1000  max=1000  avg=1000 bytes.
Out-of-order: 0 of 1000 messages (0.00%).
Inter-arrival (us): min=80  max=13352  avg=311  p50=282  p95=356  p99=392 Mean jitter (us): 55.0