### PR TITLE
bpsh: add SSH-like remote shell over Bundle Protocol

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1091,6 +1091,8 @@ bpbin = \
 	bprecvtest \
 	bpsendfile \
 	bpsendtest \
+	bpsh \
+	bpshd \
 	bpsink \
 	bpsource \
 	cbrcustodytest \
@@ -1775,6 +1777,14 @@ bpsendfile_CFLAGS = $(bpcflags) $(AM_CFLAGS)
 bpsendtest_SOURCES = bpv7/utils/bpsendtest.c
 bpsendtest_LDADD = libici.la $(bplib)
 bpsendtest_CFLAGS = $(bpcflags) $(AM_CFLAGS)
+
+bpsh_SOURCES = bpv7/utils/bpsh.c bpv7/utils/bpsh_proto.c
+bpsh_LDADD = libici.la $(bplib) $(PTHREAD_LIBS)
+bpsh_CFLAGS = $(bpcflags) $(AM_CFLAGS)
+
+bpshd_SOURCES = bpv7/utils/bpshd.c bpv7/utils/bpshd_session.c bpv7/utils/bpsh_proto.c
+bpshd_LDADD = libici.la $(bplib) $(PTHREAD_LIBS)
+bpshd_CFLAGS = $(bpcflags) $(AM_CFLAGS)
 
 bpsink_SOURCES = bpv7/test/bpsink.c
 bpsink_LDADD = libici.la $(bplib)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1216,6 +1216,8 @@ bpextra = \
 	bpv7/doc/pod1/bprecvtest.pod \
 	bpv7/doc/pod1/bpsecadmin.pod \
 	bpv7/doc/pod1/bpsendfile.pod \
+	bpv7/doc/pod1/bpsh.pod \
+	bpv7/doc/pod1/bpshd.pod \
 	bpv7/doc/pod1/bpsendtest.pod \
 	bpv7/doc/pod1/bpsink.pod \
 	bpv7/doc/pod1/bpsource.pod \
@@ -1306,6 +1308,8 @@ bpmans = \
 	bpv7/doc/bprecvtest.1 \
 	bpv7/doc/bpsecadmin.1 \
 	bpv7/doc/bpsendfile.1 \
+	bpv7/doc/bpsh.1 \
+	bpv7/doc/bpshd.1 \
 	bpv7/doc/bpsendtest.1 \
 	bpv7/doc/bpsink.1 \
 	bpv7/doc/bpsource.1 \

--- a/bpv7/doc/pod1/bpsh.pod
+++ b/bpv7/doc/pod1/bpsh.pod
@@ -1,0 +1,137 @@
+=head1 NAME
+
+bpsh - Bundle Protocol remote shell client
+
+=head1 SYNOPSIS
+
+B<bpsh> B<-h> I<remoteEID> B<-l> I<localEID> [B<-c> I<command>]
+
+B<bpsh> I<localEID> I<remoteEID>
+
+=head1 DESCRIPTION
+
+B<bpsh> is an SSH-like remote shell client that runs commands on a remote
+node over Bundle Protocol version 7.  It connects to a B<bpshd> daemon
+listening on I<remoteEID>, which executes the submitted commands in a
+persistent B</bin/sh> and returns standard output, standard error, and the
+exit code in separate bundles.  Replies are delivered to I<localEID>, which
+B<bpsh> opens as its own endpoint.
+
+Because the transport is the Bundle Protocol, B<bpsh> tolerates long delays
+and link disruptions: a command and its output are carried in
+store-and-forward bundles rather than over a continuous connection.
+
+By default B<bpsh> runs an interactive read-eval-print loop (REPL).  The
+prompt shows the working directory of the remote shell, and because a single
+B</bin/sh> persists for the whole session, B<cd>, environment variables, and
+shell functions carry over from one command to the next.  The REPL supports
+in-line editing (left/right/home/end/delete), command history on the up and
+down arrow keys, and a B<history> builtin.  Typing B<exit> closes the session
+and leaves the REPL.
+
+With B<-c>, B<bpsh> runs a single I<command> in one-shot mode and exits with
+the remote command's exit code.  If standard input is not a terminal it is
+forwarded to the remote command as bundles, allowing input to be piped to the
+remote shell.
+
+The positional form B<bpsh> I<localEID> I<remoteEID> is accepted as a
+backward-compatible shorthand for B<-l> I<localEID> B<-h> I<remoteEID> and
+always runs the interactive REPL.
+
+B<bpsh> terminates on the SIGINT signal (^C at the prompt).
+
+=head1 EXIT STATUS
+
+=over 4
+
+=item "0"
+
+In REPL mode, B<bpsh> terminated normally.  In one-shot mode (B<-c>), the
+remote command exited with status 0.
+
+=item I<n>
+
+In one-shot mode, B<bpsh> exits with the exit code I<n> of the remote
+command.  A value of "1" may also indicate a local BP transmit/receive
+failure, loss of the local ION node, or an error reported by B<bpshd>;
+details are noted on standard error and in the B<ion.log> log file.
+
+=back
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-h> I<remoteEID>
+
+Endpoint ID of the remote B<bpshd> daemon.  Mandatory.
+
+=item B<-l> I<localEID>
+
+Local endpoint ID on which B<bpsh> receives replies.  Mandatory.
+
+=item B<-c> I<command>
+
+Run I<command> as a single one-shot request, then exit with the remote
+command's exit code.  Standard input is forwarded if it is not a terminal.
+Without B<-c>, B<bpsh> runs an interactive REPL.
+
+=back
+
+=head1 FILES
+
+No configuration files are needed.
+
+=head1 ENVIRONMENT
+
+=over 4
+
+=item NO_COLOR, TERM
+
+If NO_COLOR is set, or TERM indicates a non-capable terminal, B<bpsh>
+suppresses colored output.
+
+=back
+
+=head1 DIAGNOSTICS
+
+The following diagnostics may be issued to standard error or to the
+B<ion.log> log file:
+
+=over 4
+
+=item bpsh: bp_attach failed.
+
+B<bpadmin> has not yet initialized Bundle Protocol operations.
+
+=item bpsh: can't open local endpoint.
+
+Another application has already opened I<localEID>.  Terminate that
+application and rerun, or choose a different local endpoint.
+
+=item bpsh: failed to send INIT
+
+=item bpsh: failed to receive INIT_ACK
+
+B<bpsh> could not establish a session with the remote B<bpshd>.  Verify that
+the daemon is running on I<remoteEID> and that a contact/route exists between
+the two nodes.
+
+=item bpsh: server error: ...
+
+The remote B<bpshd> reported an out-of-band error for the session.
+
+=item bpsh: lost the local ION node
+
+The local ION node was torn down while B<bpsh> was attached.  This is
+reported as a clean exit rather than a core dump.
+
+=back
+
+=head1 BUGS
+
+Report bugs to <https://github.com/nasa-jpl/ION-DTN/issues>
+
+=head1 SEE ALSO
+
+bpshd(1), bpchat(1), bp(3)

--- a/bpv7/doc/pod1/bpshd.pod
+++ b/bpv7/doc/pod1/bpshd.pod
@@ -1,0 +1,108 @@
+=head1 NAME
+
+bpshd - Bundle Protocol remote shell daemon
+
+=head1 SYNOPSIS
+
+B<bpshd> I<listenEID>
+
+=head1 DESCRIPTION
+
+B<bpshd> is the server side of the B<bpsh> remote shell.  It listens on
+I<listenEID> for requests from B<bpsh> clients, executes their commands over
+Bundle Protocol version 7, and returns standard output, standard error, and
+the command exit code to the requesting client in separate bundles.
+
+Each client (keyed by its source endpoint ID) is given its own persistent
+B</bin/sh>, so B<cd>, environment variables, and shell functions persist
+across the commands of a session.  The exit status and the command boundary
+travel out-of-band on a dedicated control file descriptor, so standard output
+and standard error stream verbatim with no in-band sentinels.
+
+Command output is transmitted under ION flow control by way of a transmission
+attendant (see B<ionStartAttendant>): when a large volume of output is
+produced, bundle creation blocks waiting for ZCO space rather than dropping
+data.  Each command is also subject to a wall-clock timeout (300 seconds by
+default; see ENVIRONMENT) and an output cap of 16 MB; exceeding either tears
+down the command's process group.
+
+A fresh INIT from a client aborts any stalled command for that client and
+starts a new session, which provides recovery from a hung command.
+
+B<bpshd> runs until it receives SIGINT or SIGTERM, at which point it tears
+down all active sessions and detaches from BP.
+
+=head1 EXIT STATUS
+
+=over 4
+
+=item "0"
+
+B<bpshd> terminated normally after receiving SIGINT or SIGTERM.
+
+=item "1"
+
+B<bpshd> terminated due to a startup or BP failure.  Details are noted in the
+B<ion.log> log file.
+
+=back
+
+=head1 OPTIONS
+
+=over 4
+
+=item I<listenEID>
+
+The local endpoint ID on which B<bpshd> listens for client requests.
+Mandatory.
+
+=back
+
+=head1 FILES
+
+No configuration files are needed.
+
+=head1 ENVIRONMENT
+
+=over 4
+
+=item BPSHD_CMD_TIMEOUT
+
+Wall-clock limit, in seconds, for a single command before it and its shell
+are killed.  Defaults to 300.  A value of 0 disables the timeout.
+
+=back
+
+=head1 DIAGNOSTICS
+
+The following diagnostics may be issued to the B<ion.log> log file:
+
+=over 4
+
+=item bpshd: bp_attach failed.
+
+B<bpadmin> has not yet initialized Bundle Protocol operations.
+
+=item bpshd: can't open listen endpoint.
+
+Another application has already opened I<listenEID>.  Terminate that
+application and rerun, or choose a different listen endpoint.
+
+=item bpshd: can't start transmission attendant.
+
+ION system error.  Check for earlier diagnostic messages describing the cause
+of the error; correct problem and rerun.
+
+=item [i] bpshd listening on ...
+
+Informational: B<bpshd> has started and is listening on I<listenEID>.
+
+=back
+
+=head1 BUGS
+
+Report bugs to <https://github.com/nasa-jpl/ION-DTN/issues>
+
+=head1 SEE ALSO
+
+bpsh(1), bp(3)

--- a/bpv7/utils/bpsh.c
+++ b/bpv7/utils/bpsh.c
@@ -1,0 +1,1067 @@
+/*
+ * bpsh.c: SSH-like remote shell client over Bundle Protocol.
+ *
+ * Interactive REPL (default) or one-shot mode (-c <cmd>, which exits
+ * with the remote command's exit code and forwards stdin when it is
+ * not a TTY).  Each command line is sent as one REQ; the per-session
+ * reorder buffer delivers the server's STDOUT / STDERR / CWD / EXIT
+ * frames in sequence order, while ERROR frames bypass ordering as
+ * out-of-band control.
+ *
+ * The REPL offers raw-mode line editing (cursor movement, command
+ * history on the arrow keys and a "history" builtin) and shows the
+ * remote shell's working directory in the prompt.
+ */
+
+#include <bp.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <termios.h>
+#include "bpsh_proto.h"
+
+#define BPSH_LINE_BUFSIZE (8 * 1024)
+#define BPSH_MAX_BUNDLE	  (16 * 1024 * 1024)
+#define BPSH_STDIN_CHUNK  (32 * 1024)
+#define BPSH_CWD_MAX	  4096
+#define BPSH_HIST_MAX	  1000
+
+static BpSAP	       sap;
+static char	      *ownEid;
+static char	      *remoteEid;
+static char	       currentCwd[BPSH_CWD_MAX]; /* shell cwd from CWD frames */
+static uvast	       sessionId;
+static uvast	       sendSeq = 0;
+static int	       running = 1;
+static pthread_mutex_t sendMutex = PTHREAD_MUTEX_INITIALIZER;
+
+/*	Frame received from the wire, decoded, and held until the
+ *	session's next-expected seq matches.  Bytes are owned by the
+ *	struct (frame.payload aliases into them).			*/
+typedef struct PendingFrame
+{
+	BpshFrame	     frame;
+	unsigned char	    *bytes;
+	size_t		     bytesLen;
+	struct PendingFrame *next;
+} PendingFrame;
+
+static PendingFrame *pendingHead = NULL;
+static uvast	     nextRecvSeq = 0;
+
+/*	In-memory command history (oldest first), for up/down recall and
+ *	the "history" builtin.						*/
+static char	   **history;
+static int	     historyCount;
+static int	     historyCap;
+
+/*	If the local ION node is torn down (e.g. its shared memory is
+ *	removed) while bpsh is running, the next bp_send/SDR call faults
+ *	on detached shared memory.  Convert that into a clean exit with a
+ *	clear message rather than a bare "Segmentation fault".  Uses only
+ *	async-signal-safe calls.					*/
+static void handleFault(int signum)
+{
+	static const char msg[] = "\nbpsh: lost the local ION node "
+			"(memory fault); exiting.\n";
+
+	(void) signum;
+	if (write(STDERR_FILENO, msg, sizeof msg - 1) < 0)
+	{
+		/*	Nothing useful to do if even this fails.	*/
+	}
+
+	_exit(1);
+}
+
+static void handleQuit(int signum)
+{
+	(void) signum;
+	running = 0;
+	if (sap)
+	{
+		bp_interrupt(sap);
+	}
+}
+
+/*	Build a frame for our session and ship it.  The send mutex makes
+ *	seq assignment atomic with the send so the REPL thread and the
+ *	one-shot stdin forwarder can't interleave their outbound frames.	*/
+static int sendTyped(BpshMsgType type, unsigned char *payload, size_t len)
+{
+	BpshFrame out;
+	int	  rc;
+
+	memset(&out, 0, sizeof(out));
+	out.version = BPSH_VERSION;
+	out.msgType = type;
+	out.sessionId = sessionId;
+	out.payload = payload;
+	out.payloadLen = len;
+
+	pthread_mutex_lock(&sendMutex);
+	out.seqNum = sendSeq++;
+	rc = bpsh_send_frame(sap, remoteEid, &out);
+	pthread_mutex_unlock(&sendMutex);
+	return rc;
+}
+
+static int sendInit(int wantStdin)
+{
+	unsigned char flagByte = 0x01;
+
+	return sendTyped(BpshMsgInit, wantStdin ? &flagByte : NULL,
+			wantStdin ? 1 : 0);
+}
+
+static int sendStdinChunk(unsigned char *bytes, size_t len)
+{
+	return sendTyped(BpshMsgStdinChunk, bytes, len);
+}
+
+static int sendStdinEof(void)
+{
+	return sendTyped(BpshMsgStdinEof, NULL, 0);
+}
+
+static int sendReq(char *line, size_t len)
+{
+	return sendTyped(BpshMsgReq, (unsigned char *) line, len);
+}
+
+static int sendExitSession(void)
+{
+	return sendTyped(BpshMsgExitSession, NULL, 0);
+}
+
+static void freePending(PendingFrame *p)
+{
+	if (p == NULL)
+	{
+		return;
+	}
+
+	if (p->bytes)
+	{
+		MRELEASE(p->bytes);
+	}
+
+	MRELEASE(p);
+}
+
+/*	Receive one bundle (blocking), decode it, and return a heap
+ *	PendingFrame whose .bytes buffer owns the raw bundle bytes.
+ *	Returns NULL on interrupt or fatal error.			*/
+static PendingFrame *recvOnePending(void)
+{
+	while (running)
+	{
+		BpshFrame      frame;
+		unsigned char *bytes;
+		size_t	       bytesLen;
+		PendingFrame  *p;
+		int	       rc;
+
+		rc = bpsh_recv_frame(sap, BP_BLOCKING, BPSH_MAX_BUNDLE, &frame,
+				&bytes, &bytesLen, NULL, 0);
+		if (rc == BPSH_RECV_FATAL)
+		{
+			return NULL;
+		}
+
+		if (rc == BPSH_RECV_NONE)
+		{
+			if (!running)
+			{
+				return NULL;
+			}
+
+			continue;
+		}
+
+		if (rc == BPSH_RECV_SKIP)
+		{
+			continue;
+		}
+
+		p = MTAKE(sizeof(PendingFrame));
+		if (p == NULL)
+		{
+			MRELEASE(bytes);
+			continue;
+		}
+
+		memset(p, 0, sizeof(*p));
+		p->frame = frame;
+		p->bytes = bytes;
+		p->bytesLen = bytesLen;
+		return p;
+	}
+
+	return NULL;
+}
+
+/*	Pull the next ordered frame for our session.  ERROR frames
+ *	bypass ordering and are returned immediately.  Frames for other
+ *	sessions are dropped.  Returns NULL on interrupt / shutdown.
+ *	Caller must freePending() the result.				*/
+static PendingFrame *recvOrderedFrame(void)
+{
+	while (running)
+	{
+		PendingFrame  *p;
+		PendingFrame **link;
+
+		if (pendingHead != NULL
+				&& pendingHead->frame.seqNum == nextRecvSeq)
+		{
+			p = pendingHead;
+			pendingHead = p->next;
+			p->next = NULL;
+			nextRecvSeq++;
+			return p;
+		}
+
+		p = recvOnePending();
+		if (p == NULL)
+		{
+			return NULL;
+		}
+
+		if (p->frame.sessionId != sessionId)
+		{
+			freePending(p);
+			continue;
+		}
+
+		if (p->frame.msgType == BpshMsgError)
+		{
+			/*	Out-of-band: deliver immediately.	*/
+			return p;
+		}
+
+		if (p->frame.seqNum < nextRecvSeq)
+		{
+			/*	Stale duplicate.			*/
+			freePending(p);
+			continue;
+		}
+
+		if (p->frame.seqNum == nextRecvSeq)
+		{
+			nextRecvSeq++;
+			return p;
+		}
+
+		/*	Future seq: insert into sorted pending list.	*/
+		link = &pendingHead;
+		while (*link != NULL && (*link)->frame.seqNum < p->frame.seqNum)
+		{
+			link = &(*link)->next;
+		}
+
+		if (*link != NULL && (*link)->frame.seqNum == p->frame.seqNum)
+		{
+			/*	Already buffered.			*/
+			freePending(p);
+			continue;
+		}
+
+		p->next = *link;
+		*link = p;
+	}
+
+	return NULL;
+}
+
+/*	Copy a CWD frame's payload into currentCwd, truncating safely.	*/
+static void storeCwd(const unsigned char *payload, size_t len)
+{
+	if (len >= sizeof currentCwd)
+	{
+		len = sizeof currentCwd - 1;
+	}
+
+	memcpy(currentCwd, payload, len);
+	currentCwd[len] = '\0';
+}
+
+/*	Wait for INIT_ACK matching our sessionId.  Returns 0 on success.	*/
+static int awaitInitAck(void)
+{
+	while (running)
+	{
+		PendingFrame *p = recvOrderedFrame();
+
+		if (p == NULL)
+		{
+			return -1;
+		}
+
+		if (p->frame.msgType == BpshMsgInitAck)
+		{
+			freePending(p);
+			return 0;
+		}
+
+		if (p->frame.msgType == BpshMsgCwd)
+		{
+			storeCwd(p->frame.payload, p->frame.payloadLen);
+			freePending(p);
+			continue;
+		}
+
+		if (p->frame.msgType == BpshMsgError)
+		{
+			fprintf(stderr, "bpsh: server error: %.*s\n",
+					(int) p->frame.payloadLen,
+					p->frame.payload);
+			freePending(p);
+			return -1;
+		}
+
+		freePending(p);
+	}
+
+	return -1;
+}
+
+/*	Consume frames in seq order, writing STDOUT / STDERR chunks to
+ *	their respective streams as they arrive, until EXIT.		*/
+static int awaitCommandResult(int *exitCode, BpshExitCause *cause)
+{
+	while (running)
+	{
+		PendingFrame *p = recvOrderedFrame();
+
+		if (p == NULL)
+		{
+			return -1;
+		}
+
+		switch (p->frame.msgType)
+		{
+		case BpshMsgStdout:
+			fwrite(p->frame.payload, 1, p->frame.payloadLen, stdout);
+			fflush(stdout);
+			freePending(p);
+			break;
+
+		case BpshMsgStderr:
+			fwrite(p->frame.payload, 1, p->frame.payloadLen, stderr);
+			fflush(stderr);
+			freePending(p);
+			break;
+
+		case BpshMsgCwd:
+			storeCwd(p->frame.payload, p->frame.payloadLen);
+			freePending(p);
+			break;
+
+		case BpshMsgExit:
+			*exitCode = p->frame.exitCode;
+			*cause = p->frame.exitCause;
+			freePending(p);
+			return 0;
+
+		case BpshMsgError:
+			fprintf(stderr, "bpsh: server error: %.*s\n",
+					(int) p->frame.payloadLen,
+					p->frame.payload);
+			freePending(p);
+			return -1;
+
+		default:
+			freePending(p);
+			break;
+		}
+	}
+
+	return -1;
+}
+
+/*	Decide whether to colour the prompt.  Honours NO_COLOR
+ *	(https://no-color.org/) and skips when TERM is unset / "dumb".
+ *	Stdout is checked because that's where the prompt is written.	*/
+static int wantColorPrompt(void)
+{
+	const char *term;
+
+	if (!isatty(fileno(stdout)))
+	{
+		return 0;
+	}
+
+	if (getenv("NO_COLOR") != NULL)
+	{
+		return 0;
+	}
+
+	term = getenv("TERM");
+	if (term == NULL || *term == '\0' || strcmp(term, "dumb") == 0)
+	{
+		return 0;
+	}
+
+	return 1;
+}
+
+/*	Append a command to the history, dropping the oldest entry past
+ *	BPSH_HIST_MAX and skipping immediate duplicates.		*/
+static void historyAdd(const char *line)
+{
+	char *copy;
+
+	if (historyCount > 0
+			&& strcmp(history[historyCount - 1], line) == 0)
+	{
+		return;
+	}
+
+	copy = MTAKE(strlen(line) + 1);
+	if (copy == NULL)
+	{
+		return;
+	}
+
+	strcpy(copy, line);
+
+	if (historyCount == BPSH_HIST_MAX)
+	{
+		MRELEASE(history[0]);
+		memmove(history, history + 1,
+				(historyCount - 1) * sizeof(char *));
+		historyCount--;
+	}
+
+	if (historyCount == historyCap)
+	{
+		int	newCap = historyCap == 0 ? 64 : historyCap * 2;
+		char  **bigger = MTAKE(newCap * sizeof(char *));
+
+		if (bigger == NULL)
+		{
+			MRELEASE(copy);
+			return;
+		}
+
+		if (history != NULL)
+		{
+			memcpy(bigger, history,
+					historyCount * sizeof(char *));
+			MRELEASE(history);
+		}
+
+		history = bigger;
+		historyCap = newCap;
+	}
+
+	history[historyCount++] = copy;
+}
+
+/*	Print the command history, numbered, like a shell's "history".	*/
+static void historyPrint(void)
+{
+	int i;
+
+	for (i = 0; i < historyCount; i++)
+	{
+		printf("%5d  %s\n", i + 1, history[i]);
+	}
+
+	fflush(stdout);
+}
+
+/*	Replace the edit buffer with src (cursor to end).		*/
+static void loadLine(char *buf, size_t size, size_t *len, size_t *pos,
+		const char *src)
+{
+	size_t n = strlen(src);
+
+	if (n > size - 1)
+	{
+		n = size - 1;
+	}
+
+	memcpy(buf, src, n);
+	buf[n] = '\0';
+	*len = n;
+	*pos = n;
+}
+
+/*	Repaint the prompt and current line, then park the cursor at the
+ *	editing position.  The whole line is reprinted from column 0 so a
+ *	coloured prompt and any post-cursor text stay correct; this assumes
+ *	the line doesn't wrap, which is fine for typical command lengths.*/
+static void redrawLine(const char *prompt, const char *buf, size_t len,
+		size_t pos)
+{
+	printf("\r%s%.*s\033[K", prompt, (int) len, buf);
+	if (pos < len)
+	{
+		printf("\033[%uD", (unsigned) (len - pos));
+	}
+
+	fflush(stdout);
+}
+
+/*	Read one line from a TTY with minimal in-line editing: printable
+ *	bytes insert at the cursor, Backspace deletes, Left/Right (and
+ *	Home/End) move within the line, and arrow Up/Down -- plus any other
+ *	escape sequence -- are swallowed rather than echoed as text.  The
+ *	prompt is drawn here.  On Enter the line (without the newline) is
+ *	stored in buf and 0 is returned; -1 is returned on end-of-input
+ *	(Ctrl+D on an empty line) or interrupt (Ctrl+C).		*/
+static int readLineRaw(char *buf, size_t size, const char *prompt)
+{
+	struct termios orig;
+	struct termios raw;
+	size_t	       len = 0;
+	size_t	       pos = 0;
+	int	       ret = 0;
+	int	       hpos = historyCount;	/* == count means the new line	*/
+	char	       saved[BPSH_LINE_BUFSIZE];	/* in-progress line stash	*/
+
+	saved[0] = '\0';
+
+	if (tcgetattr(STDIN_FILENO, &orig) < 0)
+	{
+		/*	Not a real TTY after all: fall back to fgets.	*/
+		printf("%s", prompt);
+		fflush(stdout);
+		return fgets(buf, (int) size, stdin) == NULL ? -1 : 0;
+	}
+
+	raw = orig;
+	/*	Character-at-a-time, no echo; keep ISIG so Ctrl+C still
+	 *	raises SIGINT and unwinds the session as before.	*/
+	raw.c_lflag &= ~(ICANON | ECHO);
+	raw.c_cc[VMIN] = 1;
+	raw.c_cc[VTIME] = 0;
+	tcsetattr(STDIN_FILENO, TCSANOW, &raw);
+
+	buf[0] = '\0';
+	redrawLine(prompt, buf, len, pos);
+
+	while (running)
+	{
+		unsigned char c;
+		ssize_t	      n = read(STDIN_FILENO, &c, 1);
+
+		if (n < 0)
+		{
+			ret = -1;	/*	EINTR (Ctrl+C) or error.	*/
+			break;
+		}
+
+		if (n == 0)		/*	stdin closed.			*/
+		{
+			ret = (len == 0) ? -1 : 0;
+			break;
+		}
+
+		if (c == '\r' || c == '\n')
+		{
+			break;		/*	Line complete.			*/
+		}
+
+		if (c == 4)		/*	Ctrl+D.				*/
+		{
+			if (len == 0)
+			{
+				ret = -1;
+				break;
+			}
+
+			continue;	/*	Ignore mid-line.		*/
+		}
+
+		if (c == 127 || c == 8)	/*	Backspace.			*/
+		{
+			if (pos > 0)
+			{
+				memmove(buf + pos - 1, buf + pos, len - pos);
+				pos--;
+				len--;
+				buf[len] = '\0';
+				redrawLine(prompt, buf, len, pos);
+			}
+
+			continue;
+		}
+
+		if (c == 27)		/*	Escape sequence.		*/
+		{
+			unsigned char seq0;
+			unsigned char seq1;
+
+			if (read(STDIN_FILENO, &seq0, 1) != 1)
+			{
+				continue;
+			}
+
+			if (seq0 != '[' && seq0 != 'O')
+			{
+				continue;	/*	Bare ESC / Alt-<key>.	*/
+			}
+
+			if (read(STDIN_FILENO, &seq1, 1) != 1)
+			{
+				continue;
+			}
+
+			if (seq1 >= '0' && seq1 <= '9')
+			{
+				/*	Extended seq (Del/Home/End/PgUp...):
+				 *	consume through the final '~'.		*/
+				unsigned char t;
+				while (read(STDIN_FILENO, &t, 1) == 1 && t != '~')
+				{
+					;
+				}
+
+				if (seq1 == '3')			/* Delete */
+				{
+					if (pos < len)
+					{
+						memmove(buf + pos, buf + pos + 1,
+								len - pos - 1);
+						len--;
+						buf[len] = '\0';
+						redrawLine(prompt, buf, len, pos);
+					}
+				}
+				else if (seq1 == '1' || seq1 == '7')	/* Home	*/
+				{
+					pos = 0;
+					redrawLine(prompt, buf, len, pos);
+				}
+				else if (seq1 == '4' || seq1 == '8')	/* End	*/
+				{
+					pos = len;
+					redrawLine(prompt, buf, len, pos);
+				}
+
+				continue;
+			}
+
+			switch (seq1)
+			{
+			case 'C':		/*	Right arrow.		*/
+				if (pos < len)
+				{
+					pos++;
+					redrawLine(prompt, buf, len, pos);
+				}
+
+				break;
+
+			case 'D':		/*	Left arrow.		*/
+				if (pos > 0)
+				{
+					pos--;
+					redrawLine(prompt, buf, len, pos);
+				}
+
+				break;
+
+			case 'H':		/*	Home.			*/
+				pos = 0;
+				redrawLine(prompt, buf, len, pos);
+				break;
+
+			case 'F':		/*	End.			*/
+				pos = len;
+				redrawLine(prompt, buf, len, pos);
+				break;
+
+			case 'A':		/*	Up: older history.	*/
+				if (hpos > 0)
+				{
+					if (hpos == historyCount)
+					{
+						/*	Stash the in-progress
+						 *	line to restore later.	*/
+						memcpy(saved, buf, len);
+						saved[len] = '\0';
+					}
+
+					hpos--;
+					loadLine(buf, size, &len, &pos,
+							history[hpos]);
+					redrawLine(prompt, buf, len, pos);
+				}
+
+				break;
+
+			case 'B':		/*	Down: newer history.	*/
+				if (hpos < historyCount)
+				{
+					hpos++;
+					loadLine(buf, size, &len, &pos,
+							hpos == historyCount ?
+								saved :
+								history[hpos]);
+					redrawLine(prompt, buf, len, pos);
+				}
+
+				break;
+
+			default:		/*	Other CSI: ignore.	*/
+				break;
+			}
+
+			continue;
+		}
+
+		if (c < 32)		/*	Other control bytes: ignore.	*/
+		{
+			continue;
+		}
+
+		/*	Printable byte: insert at the cursor.			*/
+		if (len + 1 < size)
+		{
+			memmove(buf + pos + 1, buf + pos, len - pos);
+			buf[pos] = (char) c;
+			pos++;
+			len++;
+			buf[len] = '\0';
+			redrawLine(prompt, buf, len, pos);
+		}
+	}
+
+	tcsetattr(STDIN_FILENO, TCSANOW, &orig);
+	buf[len] = '\0';
+	putchar('\n');
+	fflush(stdout);
+	return running ? ret : -1;
+}
+
+/*	Compose the REPL prompt: bpsh#<local>@<remote>, with the shell's
+ *	cwd appended ":<cwd>" once known -- the way a normal shell shows
+ *	the working directory.  Coloured when the terminal supports it.	*/
+static void buildPrompt(char *out, size_t size, int color)
+{
+	const char *cwd = currentCwd[0] != '\0' ? currentCwd : NULL;
+
+	if (color)
+	{
+		/*	bright-cyan "bpsh#", green local EID, default "@",
+		 *	bright-blue remote EID, yellow cwd.		*/
+		if (cwd)
+		{
+			isprintf(out, (int) size,
+					"\033[1;36mbpsh\033[0m#\033[32m%s\033[0m@"
+					"\033[1;34m%s\033[0m:\033[33m%s\033[0m> ",
+					ownEid, remoteEid, cwd);
+		}
+		else
+		{
+			isprintf(out, (int) size,
+					"\033[1;36mbpsh\033[0m#\033[32m%s\033[0m@"
+					"\033[1;34m%s\033[0m> ",
+					ownEid, remoteEid);
+		}
+	}
+	else if (cwd)
+	{
+		isprintf(out, (int) size, "bpsh#%s@%s:%s> ", ownEid, remoteEid,
+				cwd);
+	}
+	else
+	{
+		isprintf(out, (int) size, "bpsh#%s@%s> ", ownEid, remoteEid);
+	}
+}
+
+static int repl(void)
+{
+	char	      line[BPSH_LINE_BUFSIZE];
+	char	      prompt[BPSH_CWD_MAX + 256];
+	size_t	      len;
+	int	      exitCode;
+	BpshExitCause cause;
+	int	      isTty = isatty(fileno(stdin));
+	int	      color = isTty && wantColorPrompt();
+
+	while (running)
+	{
+		buildPrompt(prompt, sizeof prompt, color);
+
+		if (isTty)
+		{
+			/*	Raw-mode editor: arrow keys navigate / are
+			 *	swallowed instead of being typed.		*/
+			if (readLineRaw(line, sizeof line, prompt) < 0)
+			{
+				break;
+			}
+		}
+		else if (fgets(line, sizeof(line), stdin) == NULL)
+		{
+			break;		/*	End of piped stdin.		*/
+		}
+
+		len = strlen(line);
+		while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+		{
+			len--;
+		}
+
+		if (len == 0)
+		{
+			continue;
+		}
+
+		line[len] = '\0';
+		historyAdd(line);
+
+		/*	"history" is a client-side builtin: list the locally
+		 *	kept command history instead of running it remotely.	*/
+		if (strcmp(line, "history") == 0)
+		{
+			historyPrint();
+			continue;
+		}
+
+		if (sendReq(line, len) < 0)
+		{
+			fprintf(stderr, "bpsh: failed to send REQ\n");
+			return -1;
+		}
+
+		if (awaitCommandResult(&exitCode, &cause) < 0)
+		{
+			return -1;
+		}
+
+		if (cause == BpshCauseKilled)
+		{
+			if (isTty)
+			{
+				fprintf(stderr, "[bpsh: session closed]\n");
+			}
+
+			break;
+		}
+
+		if (cause != BpshCauseNormal)
+		{
+			fprintf(stderr,
+					"[bpsh: command exited (%s)"
+					" code=%d]\n",
+					bpsh_cause_name(cause), exitCode);
+		}
+	}
+
+	return 0;
+}
+
+/*	Forward bpsh's own stdin to the remote command via STDIN_CHUNK
+ *	bundles, then send STDIN_EOF.  Used only in one-shot mode (-c)
+ *	when stdin is not a TTY.					*/
+static void *stdinForwarder(void *arg)
+{
+	unsigned char buf[BPSH_STDIN_CHUNK];
+
+	(void) arg;
+
+	while (running)
+	{
+		ssize_t n = read(STDIN_FILENO, buf, sizeof(buf));
+
+		if (n < 0)
+		{
+			if (errno == EINTR)
+			{
+				continue;
+			}
+
+			break;
+		}
+
+		if (n == 0)
+		{
+			break;
+		}
+
+		if (sendStdinChunk(buf, (size_t) n) < 0)
+		{
+			break;
+		}
+	}
+
+	sendStdinEof();
+	return NULL;
+}
+
+static void usage(void)
+{
+	fprintf(stderr,
+			"Usage: bpsh -h <remote EID> [-l <local EID>] [-c <cmd>]\n"
+			"       bpsh <local EID> <remote EID>     (positional, REPL)\n"
+			"\n"
+			"  -h <remote EID>  remote bpshd endpoint (mandatory)\n"
+			"  -l <local EID>   local endpoint for replies (mandatory)\n"
+			"  -c <cmd>         run <cmd> as one-shot, exit with its rc.\n"
+			"                   Stdin is forwarded if not a TTY.\n"
+			"\n"
+			"Without -c, runs an interactive REPL.\n");
+}
+
+int main(int argc, char **argv)
+{
+	const char   *cmd = NULL;
+	int	      opt;
+	int	      wantStdin;
+	int	      exitCode = 0;
+	BpshExitCause cause = BpshCauseNormal;
+	pthread_t     forwarder;
+	int	      forwarderStarted = 0;
+
+	while ((opt = getopt(argc, argv, "h:l:c:")) != -1)
+	{
+		switch (opt)
+		{
+		case 'h':
+			remoteEid = optarg;
+			break;
+		case 'l':
+			ownEid = optarg;
+			break;
+		case 'c':
+			cmd = optarg;
+			break;
+		default:
+			usage();
+			return 1;
+		}
+	}
+
+	/*	Backward-compatible positional fallback.		*/
+	if (ownEid == NULL && remoteEid == NULL && argc - optind >= 2)
+	{
+		ownEid = argv[optind];
+		remoteEid = argv[optind + 1];
+	}
+
+	if (ownEid == NULL || remoteEid == NULL)
+	{
+		usage();
+		return 1;
+	}
+
+	if (bp_attach() < 0)
+	{
+		putErrmsg("bpsh: bp_attach failed.", NULL);
+		return 1;
+	}
+
+	if (bp_open(ownEid, &sap) < 0)
+	{
+		putErrmsg("bpsh: can't open local endpoint.", ownEid);
+		bp_detach();
+		return 1;
+	}
+
+	/*	Register SIGINT without SA_RESTART so that fgets in the
+	 *	REPL returns EINTR on Ctrl+C and the loop exits cleanly.
+	 *	signal() on glibc keeps SA_RESTART set, which would
+	 *	silently swallow Ctrl+C at the prompt.			*/
+	{
+		struct sigaction sa;
+
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = handleQuit;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		sigaction(SIGINT, &sa, NULL);
+
+		/*	Now that we're attached to ION, a memory fault is
+		 *	most likely the node being torn down underneath us;
+		 *	report it cleanly instead of dumping core.	*/
+		sa.sa_handler = handleFault;
+		sigaction(SIGSEGV, &sa, NULL);
+		sigaction(SIGBUS, &sa, NULL);
+	}
+
+	srand((unsigned int) (getpid() ^ time(NULL)));
+	sessionId = ((uvast) rand() << 32) | (uvast) rand();
+
+	/*	One-shot with non-TTY stdin = stdin forwarding mode.	*/
+	wantStdin = (cmd != NULL && !isatty(STDIN_FILENO));
+
+	if (sendInit(wantStdin) < 0)
+	{
+		fprintf(stderr, "bpsh: failed to send INIT\n");
+		bp_close(sap);
+		bp_detach();
+		return 1;
+	}
+
+	if (awaitInitAck() < 0)
+	{
+		fprintf(stderr, "bpsh: failed to receive INIT_ACK\n");
+		bp_close(sap);
+		bp_detach();
+		return 1;
+	}
+
+	if (cmd != NULL)
+	{
+		/*	One-shot: send REQ, optionally start stdin
+		 *	forwarder, await result, exit with rc.		*/
+		char *cmdCopy = MTAKE(strlen(cmd) + 1);
+
+		if (cmdCopy == NULL)
+		{
+			fprintf(stderr, "bpsh: out of memory\n");
+			exitCode = 1;
+			goto done;
+		}
+
+		strcpy(cmdCopy, cmd);
+		if (sendReq(cmdCopy, strlen(cmdCopy)) < 0)
+		{
+			fprintf(stderr, "bpsh: failed to send REQ\n");
+			MRELEASE(cmdCopy);
+			exitCode = 1;
+			goto done;
+		}
+
+		MRELEASE(cmdCopy);
+
+		if (wantStdin)
+		{
+			if (pthread_begin(&forwarder, NULL, stdinForwarder, NULL)
+					< 0)
+			{
+				fprintf(stderr, "bpsh: stdin forwarder thread failed\n");
+				exitCode = 1;
+				goto done;
+			}
+
+			forwarderStarted = 1;
+		}
+
+		if (awaitCommandResult(&exitCode, &cause) < 0)
+		{
+			exitCode = 1;
+		}
+
+		if (forwarderStarted)
+		{
+			pthread_join(forwarder, NULL);
+		}
+	}
+	else
+	{
+		repl();
+	}
+
+done:
+	sendExitSession();
+	bp_close(sap);
+	bp_detach();
+	return exitCode;
+}

--- a/bpv7/utils/bpsh.c
+++ b/bpv7/utils/bpsh.c
@@ -16,6 +16,7 @@
 #include <bp.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <poll.h>
 #include <termios.h>
 #include "bpsh_proto.h"
 
@@ -868,7 +869,34 @@ static void *stdinForwarder(void *arg)
 
 	while (running)
 	{
-		ssize_t n = read(STDIN_FILENO, buf, sizeof(buf));
+		struct pollfd pfd;
+		ssize_t       n;
+		int           pr;
+
+		/*	Poll with a short timeout rather than blocking in
+		 *	read(), so that when the remote command exits the
+		 *	main thread can clear `running` and we notice it and
+		 *	stop, instead of blocking until our stdin is closed.	*/
+		pfd.fd = STDIN_FILENO;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		pr = poll(&pfd, 1, 200);
+		if (pr == 0)		/*	Timeout: re-check running.	*/
+		{
+			continue;
+		}
+
+		if (pr < 0)
+		{
+			if (errno == EINTR)
+			{
+				continue;
+			}
+
+			break;
+		}
+
+		n = read(STDIN_FILENO, buf, sizeof(buf));
 
 		if (n < 0)
 		{
@@ -1051,6 +1079,10 @@ int main(int argc, char **argv)
 
 		if (forwarderStarted)
 		{
+			/*	The remote command has exited; stop forwarding
+			 *	stdin so we don't block waiting for our stdin
+			 *	to be closed.				*/
+			running = 0;
 			pthread_join(forwarder, NULL);
 		}
 	}

--- a/bpv7/utils/bpsh_proto.c
+++ b/bpv7/utils/bpsh_proto.c
@@ -1,0 +1,480 @@
+/*
+ * bpsh_proto.c: CBOR encode/decode for the bpsh wire format, plus the
+ * shared frame send/receive helpers used by bpsh and bpshd.
+ */
+
+#include "bpsh_proto.h"
+#include "cbor.h"
+
+int bpsh_encode(const BpshFrame *frame, unsigned char *buf, size_t buflen)
+{
+	unsigned char *cursor = buf;
+	unsigned char *end = buf + buflen;
+	uvast	       needed;
+
+	if (frame == NULL || buf == NULL)
+	{
+		return -1;
+	}
+
+	/*	Conservative size check: header + (payload | exit pair).
+	 *	Worst case for bytestring payload = overhead + payloadLen.
+	 *	EXIT carries a 2-element array of small ints, well under
+	 *	BPSH_FRAME_OVERHEAD.					*/
+	if (frame->msgType == BpshMsgExit)
+	{
+		needed = BPSH_FRAME_OVERHEAD;
+	}
+	else
+	{
+		needed = BPSH_FRAME_OVERHEAD + frame->payloadLen;
+	}
+
+	if (buflen < needed)
+	{
+		return -1;
+	}
+
+	cbor_encode_array_open(5, &cursor);
+	cbor_encode_integer((uvast) frame->version, &cursor);
+	cbor_encode_integer((uvast) frame->msgType, &cursor);
+	cbor_encode_integer(frame->sessionId, &cursor);
+	cbor_encode_integer(frame->seqNum, &cursor);
+
+	switch (frame->msgType)
+	{
+	case BpshMsgInitAck:
+	case BpshMsgStdinEof:
+	case BpshMsgExitSession:
+		cbor_encode_byte_string(NULL, 0, &cursor);
+		break;
+
+	/*	INIT carries an optional flag byte (0x01 = client will
+	 *	send STDIN_CHUNK; absent / 0x00 = REPL mode).		*/
+	case BpshMsgInit:
+	case BpshMsgReq:
+	case BpshMsgStdinChunk:
+	case BpshMsgStdout:
+	case BpshMsgStderr:
+	case BpshMsgError:
+	case BpshMsgCwd:
+		cbor_encode_byte_string(frame->payload, frame->payloadLen,
+				&cursor);
+		break;
+
+	case BpshMsgExit:
+		cbor_encode_array_open(2, &cursor);
+		cbor_encode_signed_int((vast) frame->exitCode, &cursor);
+		cbor_encode_integer((uvast) frame->exitCause, &cursor);
+		break;
+
+	default:
+		return -1;
+	}
+
+	if (cursor > end)
+	{
+		return -1;
+	}
+
+	return (int) (cursor - buf);
+}
+
+int bpsh_decode(unsigned char *buf, size_t buflen, BpshFrame *frame)
+{
+	unsigned char *cursor = buf;
+	unsigned int   bytesBuffered = (unsigned int) buflen;
+	uvast	       arrSize;
+	uvast	       val;
+	uvast	       bsSize;
+	uvast	       exitArrSize;
+	vast	       exitCode;
+
+	if (buf == NULL || frame == NULL || buflen == 0)
+	{
+		return -1;
+	}
+
+	arrSize = 5; /* expected outer array size */
+	if (cbor_decode_array_open(&arrSize, &cursor, &bytesBuffered) == 0)
+	{
+		return -1;
+	}
+
+	if (cbor_decode_integer(&val, CborAny, &cursor, &bytesBuffered) == 0)
+	{
+		return -1;
+	}
+
+	frame->version = (int) val;
+
+	if (cbor_decode_integer(&val, CborAny, &cursor, &bytesBuffered) == 0)
+	{
+		return -1;
+	}
+
+	frame->msgType = (BpshMsgType) val;
+
+	if (cbor_decode_integer(&frame->sessionId, CborAny, &cursor, &bytesBuffered)
+			== 0)
+	{
+		return -1;
+	}
+
+	if (cbor_decode_integer(&frame->seqNum, CborAny, &cursor, &bytesBuffered)
+			== 0)
+	{
+		return -1;
+	}
+
+	frame->payload = NULL;
+	frame->payloadLen = 0;
+	frame->exitCode = 0;
+	frame->exitCause = BpshCauseNormal;
+
+	switch (frame->msgType)
+	{
+	case BpshMsgInitAck:
+	case BpshMsgStdinEof:
+	case BpshMsgExitSession:
+		/*	Input *size is the maximum allowed bytestring
+		 *	length; for empty-payload messages we pin it to
+		 *	0 so any non-empty bytestring is rejected.	*/
+		bsSize = 0;
+		if (cbor_decode_byte_string(NULL, &bsSize, &cursor, &bytesBuffered)
+				== 0)
+		{
+			return -1;
+		}
+
+		break;
+
+	/*	INIT now carries an optional flag bytestring
+	 *	(0 or 1 byte; payload[0] == 0x01 means stdin-forward).	*/
+	case BpshMsgInit:
+	case BpshMsgReq:
+	case BpshMsgStdinChunk:
+	case BpshMsgStdout:
+	case BpshMsgStderr:
+	case BpshMsgError:
+	case BpshMsgCwd:
+		bsSize = bytesBuffered;
+		if (cbor_decode_byte_string(NULL, &bsSize, &cursor, &bytesBuffered)
+				== 0)
+		{
+			return -1;
+		}
+
+		/*	cbor_decode_byte_string with NULL value advances
+		 *	cursor only to the start of the bytes; advance
+		 *	past them manually for correct accounting.	*/
+		frame->payload = cursor;
+		frame->payloadLen = bsSize;
+		cursor += bsSize;
+		bytesBuffered -= bsSize;
+		break;
+
+	case BpshMsgExit:
+		exitArrSize = 2; /* expected EXIT inner array size */
+		if (cbor_decode_array_open(&exitArrSize, &cursor, &bytesBuffered)
+				== 0)
+		{
+			return -1;
+		}
+
+		if (cbor_decode_signed_int(&exitCode, &cursor, &bytesBuffered)
+				== 0)
+		{
+			return -1;
+		}
+
+		frame->exitCode = (int) exitCode;
+
+		if (cbor_decode_integer(&val, CborAny, &cursor, &bytesBuffered)
+				== 0)
+		{
+			return -1;
+		}
+
+		frame->exitCause = (BpshExitCause) val;
+		break;
+
+	default:
+		return -1;
+	}
+
+	return (int) (cursor - buf);
+}
+
+char *bpsh_msgtype_name(BpshMsgType t)
+{
+	switch (t)
+	{
+	case BpshMsgInit:
+		return "INIT";
+	case BpshMsgInitAck:
+		return "INIT_ACK";
+	case BpshMsgReq:
+		return "REQ";
+	case BpshMsgStdinChunk:
+		return "STDIN_CHUNK";
+	case BpshMsgStdinEof:
+		return "STDIN_EOF";
+	case BpshMsgStdout:
+		return "STDOUT";
+	case BpshMsgStderr:
+		return "STDERR";
+	case BpshMsgExit:
+		return "EXIT";
+	case BpshMsgError:
+		return "ERROR";
+	case BpshMsgExitSession:
+		return "EXIT_SESSION";
+	case BpshMsgCwd:
+		return "CWD";
+	default:
+		return "?";
+	}
+}
+
+char *bpsh_cause_name(BpshExitCause c)
+{
+	switch (c)
+	{
+	case BpshCauseNormal:
+		return "normal";
+	case BpshCauseSignaled:
+		return "signaled";
+	case BpshCauseTimeout:
+		return "timeout";
+	case BpshCauseKilled:
+		return "killed";
+	case BpshCauseOutputLimit:
+		return "output-limit";
+	default:
+		return "?";
+	}
+}
+
+static ReqAttendant *sendAttendant = NULL;
+
+void bpsh_set_send_attendant(ReqAttendant *attendant)
+{
+	sendAttendant = attendant;
+}
+
+int bpsh_send_frame(BpSAP sap, char *destEid, const BpshFrame *frame)
+{
+	Sdr	       sdr = bp_get_sdr();
+	unsigned char *buf;
+	int	       nbytes;
+	Object	       payload;
+	Object	       zco;
+	Object	       newBundle;
+	size_t	       bufsize;
+
+	if (frame == NULL || destEid == NULL)
+	{
+		return -1;
+	}
+
+	bufsize = BPSH_FRAME_OVERHEAD + frame->payloadLen;
+	buf = MTAKE(bufsize);
+	if (buf == NULL)
+	{
+		putErrmsg("bpsh: out of memory encoding frame.", NULL);
+		return -1;
+	}
+
+	nbytes = bpsh_encode(frame, buf, bufsize);
+	if (nbytes < 0)
+	{
+		MRELEASE(buf);
+		putErrmsg("bpsh: frame encode failed.", NULL);
+		return -1;
+	}
+
+	if (sdr_begin_xn(sdr) < 0)
+	{
+		MRELEASE(buf);
+		return -1;
+	}
+
+	payload = sdr_malloc(sdr, nbytes);
+	if (payload)
+	{
+		sdr_write(sdr, payload, (char *) buf, nbytes);
+	}
+
+	if (sdr_end_xn(sdr) < 0 || payload == 0)
+	{
+		MRELEASE(buf);
+		putErrmsg("bpsh: no SDR space for frame.", NULL);
+		return -1;
+	}
+
+	MRELEASE(buf);
+
+	/*	With an attendant this blocks until outbound ZCO space is
+	 *	available rather than failing -- giving large output flow
+	 *	control instead of a dropped (and sequence-gapping) frame.	*/
+	zco = ionCreateZco(ZcoSdrSource, payload, 0, nbytes, BP_STD_PRIORITY, 0,
+			ZcoOutbound, sendAttendant);
+	if (zco == 0 || zco == (Object) ERROR)
+	{
+		putErrmsg("bpsh: can't create ZCO.", NULL);
+		return -1;
+	}
+
+	if (bp_send(sap, destEid, NULL, 86400, BP_STD_PRIORITY,
+			    NoCustodyRequested, 0, 0, NULL, zco, &newBundle)
+			<= 0)
+	{
+		putErrmsg("bpsh: bp_send failed.", destEid);
+		if (sdr_begin_xn(sdr) >= 0)
+		{
+			zco_destroy(sdr, zco);
+			oK(sdr_end_xn(sdr));
+		}
+
+		return -1;
+	}
+
+	return 0;
+}
+
+int bpsh_send_ctl(BpSAP sap, char *destEid, BpshMsgType type, uvast sessionId,
+		uvast seq)
+{
+	BpshFrame out;
+
+	memset(&out, 0, sizeof(out));
+	out.version = BPSH_VERSION;
+	out.msgType = type;
+	out.sessionId = sessionId;
+	out.seqNum = seq;
+	return bpsh_send_frame(sap, destEid, &out);
+}
+
+int bpsh_send_bytes(BpSAP sap, char *destEid, BpshMsgType type, uvast sessionId,
+		uvast seq, unsigned char *bytes, size_t len)
+{
+	BpshFrame out;
+
+	memset(&out, 0, sizeof(out));
+	out.version = BPSH_VERSION;
+	out.msgType = type;
+	out.sessionId = sessionId;
+	out.seqNum = seq;
+	out.payload = bytes;
+	out.payloadLen = len;
+	return bpsh_send_frame(sap, destEid, &out);
+}
+
+int bpsh_send_exit(BpSAP sap, char *destEid, uvast sessionId, uvast seq,
+		int code, BpshExitCause cause)
+{
+	BpshFrame out;
+
+	memset(&out, 0, sizeof(out));
+	out.version = BPSH_VERSION;
+	out.msgType = BpshMsgExit;
+	out.sessionId = sessionId;
+	out.seqNum = seq;
+	out.exitCode = code;
+	out.exitCause = cause;
+	return bpsh_send_frame(sap, destEid, &out);
+}
+
+int bpsh_send_error(BpSAP sap, char *destEid, uvast sessionId, uvast seq,
+		char *msg)
+{
+	return bpsh_send_bytes(sap, destEid, BpshMsgError, sessionId, seq,
+			(unsigned char *) msg, strlen(msg));
+}
+
+int bpsh_recv_frame(BpSAP sap, int blocking, size_t maxLen, BpshFrame *frame,
+		unsigned char **rawBytes, size_t *rawLen, char *srcEid,
+		size_t srcEidLen)
+{
+	Sdr	       sdr = bp_get_sdr();
+	BpDelivery     dlv;
+	vast	       bundleLen;
+	ZcoReader      reader;
+	unsigned char *bytes;
+
+	*rawBytes = NULL;
+	*rawLen = 0;
+
+	if (bp_receive(sap, &dlv, blocking) < 0)
+	{
+		return BPSH_RECV_FATAL;
+	}
+
+	if (dlv.result == BpEndpointStopped)
+	{
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_FATAL;
+	}
+
+	if (dlv.result != BpPayloadPresent || dlv.adu == 0)
+	{
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_NONE;
+	}
+
+	if (sdr_begin_xn(sdr) < 0)
+	{
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_SKIP;
+	}
+
+	bundleLen = zco_source_data_length(sdr, dlv.adu);
+	if (bundleLen <= 0 || (maxLen != 0 && (size_t) bundleLen > maxLen))
+	{
+		sdr_exit_xn(sdr);
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_SKIP;
+	}
+
+	bytes = MTAKE((size_t) bundleLen);
+	if (bytes == NULL)
+	{
+		sdr_exit_xn(sdr);
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_SKIP;
+	}
+
+	zco_start_receiving(dlv.adu, &reader);
+	if (zco_receive_source(sdr, &reader, bundleLen, (char *) bytes) < 0)
+	{
+		MRELEASE(bytes);
+		sdr_cancel_xn(sdr);
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_SKIP;
+	}
+
+	if (sdr_end_xn(sdr) < 0)
+	{
+		MRELEASE(bytes);
+		bp_release_delivery(&dlv, 1);
+		return BPSH_RECV_SKIP;
+	}
+
+	if (srcEid != NULL && srcEidLen > 0)
+	{
+		istrcpy(srcEid, dlv.bundleSourceEid, srcEidLen);
+	}
+
+	bp_release_delivery(&dlv, 1);
+
+	if (bpsh_decode(bytes, (size_t) bundleLen, frame) < 0)
+	{
+		MRELEASE(bytes);
+		return BPSH_RECV_SKIP;
+	}
+
+	*rawBytes = bytes;
+	*rawLen = (size_t) bundleLen;
+	return BPSH_RECV_OK;
+}

--- a/bpv7/utils/bpsh_proto.h
+++ b/bpv7/utils/bpsh_proto.h
@@ -1,0 +1,135 @@
+/*
+ * bpsh_proto.h: wire format for bpsh / bpshd.
+ *
+ * Each bundle payload is a CBOR positional array
+ *	[ version, msgType, sessionId, seqNum, payload ]
+ * where payload is either a CBOR byte string (REQ, STDIN_CHUNK,
+ * STDOUT, STDERR, CWD, ERROR; INIT carries an optional 1-byte
+ * stdin-request flag), an empty CBOR byte string (INIT_ACK,
+ * STDIN_EOF, EXIT_SESSION), or a 2-element CBOR array
+ * [ exitCode, exitCause ] (EXIT).
+ */
+
+#ifndef BPSH_PROTO_H
+#define BPSH_PROTO_H
+
+#include "bp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BPSH_VERSION	     1
+#define BPSH_DEFAULT_SERVICE 22
+
+/*	Max bundle source EID length bpsh_recv_frame will copy out.	*/
+#define BPSH_MAX_EID	     256
+
+typedef enum
+{
+	BpshMsgInit = 1,	/* C->S, no payload	*/
+	BpshMsgInitAck = 2,	/* S->C, no payload	*/
+	BpshMsgReq = 3,		/* C->S, command line	*/
+	BpshMsgStdinChunk = 4,	/* C->S, bytes		*/
+	BpshMsgStdinEof = 5,	/* C->S, no payload	*/
+	BpshMsgStdout = 6,	/* S->C, bytes		*/
+	BpshMsgStderr = 7,	/* S->C, bytes		*/
+	BpshMsgExit = 8,	/* S->C, [code, cause]	*/
+	BpshMsgError = 9,	/* S->C, message	*/
+	BpshMsgExitSession = 10, /* C->S, no payload	*/
+	BpshMsgCwd = 11		/* S->C, shell cwd path	*/
+} BpshMsgType;
+
+typedef enum
+{
+	BpshCauseNormal = 0,
+	BpshCauseSignaled = 1,
+	BpshCauseTimeout = 2,
+	BpshCauseKilled = 3,
+	BpshCauseOutputLimit = 4
+} BpshExitCause;
+
+typedef struct
+{
+	int	    version;
+	BpshMsgType msgType;
+	uvast	    sessionId;
+	uvast	    seqNum;
+
+	/*	For byte-string payloads (REQ, STDIN_CHUNK, STDOUT,
+	 *	STDERR, ERROR): pointer + length.  After bpsh_decode,
+	 *	payload points into the caller-supplied buffer; copy
+	 *	the bytes if you need to keep them past the decode
+	 *	buffer's lifetime.					*/
+	unsigned char *payload;
+	uvast	       payloadLen;
+
+	/*	For EXIT only:						*/
+	int	      exitCode;
+	BpshExitCause exitCause;
+} BpshFrame;
+
+/*	Bytes of overhead a maximal frame header consumes (array open,
+ *	four uvast ints, byte-string header).  Add this to your payload
+ *	length to size an encode buffer.				*/
+#define BPSH_FRAME_OVERHEAD 64
+
+/*	bpsh_encode: serialize frame into buf.  Returns number of bytes
+ *	written, or -1 if buf is too small or frame is malformed.	*/
+extern int bpsh_encode(const BpshFrame *frame, unsigned char *buf, size_t buflen);
+
+/*	bpsh_decode: parse a frame from buf.  Returns number of bytes
+ *	consumed on success, -1 on malformed input.  For byte-string
+ *	payloads, frame->payload aliases into buf -- do not free buf
+ *	until you are done with the frame.				*/
+extern int bpsh_decode(unsigned char *buf, size_t buflen, BpshFrame *frame);
+
+/*	The name lookup helpers for debug memo.				*/
+extern char *bpsh_msgtype_name(BpshMsgType t);
+extern char *bpsh_cause_name(BpshExitCause c);
+
+/*	bpsh_send_frame: encode frame, wrap it in a ZCO, and bp_send it
+ *	to destEid over the open endpoint sap.  Returns 0 on success,
+ *	-1 on failure.							*/
+extern int bpsh_send_frame(BpSAP sap, char *destEid, const BpshFrame *frame);
+
+/*	bpsh_set_send_attendant: register a ReqAttendant so bpsh_send_frame
+ *	creates outbound ZCOs in blocking mode -- waiting for ZCO space
+ *	instead of failing when the outbound budget is full.  This gives
+ *	the sender flow control for large output (a la bpsource).  Pass
+ *	NULL (the default) for non-blocking sends.			*/
+extern void bpsh_set_send_attendant(ReqAttendant *attendant);
+
+/*	Convenience senders that build a frame of the given kind and ship
+ *	it via bpsh_send_frame.  Each returns 0 on success, -1 on error.	*/
+extern int bpsh_send_ctl(BpSAP sap, char *destEid, BpshMsgType type,
+		uvast sessionId, uvast seq);
+extern int bpsh_send_bytes(BpSAP sap, char *destEid, BpshMsgType type,
+		uvast sessionId, uvast seq, unsigned char *bytes, size_t len);
+extern int bpsh_send_exit(BpSAP sap, char *destEid, uvast sessionId, uvast seq,
+		int code, BpshExitCause cause);
+extern int bpsh_send_error(BpSAP sap, char *destEid, uvast sessionId, uvast seq,
+		char *msg);
+
+/*	Return codes for bpsh_recv_frame.				*/
+#define BPSH_RECV_OK	 1   /* frame decoded; *rawBytes owns the bytes	*/
+#define BPSH_RECV_NONE	 0   /* no bundle (poll empty / interrupted)	*/
+#define BPSH_RECV_SKIP	 2   /* a bundle arrived but was unusable; retry	*/
+#define BPSH_RECV_FATAL	 (-1) /* bp_receive error / endpoint stopped	*/
+
+/*	bpsh_recv_frame: receive one bundle from sap (BP_BLOCKING or
+ *	BP_POLL) and decode it.  On BPSH_RECV_OK, *rawBytes is set to an
+ *	MTAKE'd buffer that owns the bundle bytes (frame->payload aliases
+ *	into it) -- the caller must MRELEASE it once done with frame;
+ *	*rawLen receives its length, and srcEid (if non-NULL) receives the
+ *	bundle source EID.  maxLen rejects oversized bundles (0 = no cap).
+ *	Returns one of the BPSH_RECV_* codes above.			*/
+extern int bpsh_recv_frame(BpSAP sap, int blocking, size_t maxLen,
+		BpshFrame *frame, unsigned char **rawBytes, size_t *rawLen,
+		char *srcEid, size_t srcEidLen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BPSH_PROTO_H */

--- a/bpv7/utils/bpshd.c
+++ b/bpv7/utils/bpshd.c
@@ -1,0 +1,468 @@
+/*
+ * bpshd.c: SSH-like remote shell daemon over Bundle Protocol.
+ *
+ * This file is the session manager: it attaches to BP, opens the
+ * listen endpoint, owns the table of live client sessions, routes
+ * decoded frames to them (INIT opens a session, REQ runs a command,
+ * EXIT_SESSION closes one), and owns the queue of bundles deferred
+ * while a command is running.  A single session's internals -- the
+ * /bin/sh child, command execution and output streaming -- live in
+ * the bpshd_session object (bpshd_session.c / .h).
+ *
+ * Still missing: bpsec gate, ionadmin configuration, idle-session
+ * reaper.
+ */
+
+#include <bp.h>
+#include "bpsh_proto.h"
+#include "bpshd_session.h"
+
+/*	Bundles received while a command was running that weren't that
+ *	session's stdin; replayed through the dispatcher once it returns.*/
+typedef struct DeferredBundle
+{
+	unsigned char	      *bytes;
+	size_t		       bytesLen;
+	char		      *sourceEid;
+	struct DeferredBundle *next;
+} DeferredBundle;
+
+static BpSAP	      sap;
+static int	      running = 1;
+static BpshSession **sessions;
+static int	      sessionCount = 0;
+static int	      sessionCap = 0;
+static DeferredBundle *deferredHead = NULL;
+static DeferredBundle *deferredTail = NULL;
+static ReqAttendant   attendant;	/* blocking transmission of output */
+static int	      attendantStarted = 0;
+
+static void handleQuit(int signum)
+{
+	(void) signum;
+	running = 0;
+	if (attendantStarted)
+	{
+		/*	Unblock a send that's waiting for ZCO space.	*/
+		ionPauseAttendant(&attendant);
+	}
+
+	if (sap)
+	{
+		bp_interrupt(sap);
+	}
+}
+
+/*	Deferred-bundle FIFO.  Append a copy of bytes / sourceEid; return
+ *	0 on success, -1 on alloc failure.				*/
+static int enqueueDeferred(const unsigned char *bytes, size_t bytesLen,
+		const char *sourceEid)
+{
+	DeferredBundle *d;
+	size_t		eidLen;
+
+	d = MTAKE(sizeof(DeferredBundle));
+	if (d == NULL)
+	{
+		return -1;
+	}
+
+	memset(d, 0, sizeof(*d));
+
+	d->bytes = MTAKE(bytesLen);
+	if (d->bytes == NULL)
+	{
+		MRELEASE(d);
+		return -1;
+	}
+
+	eidLen = strlen(sourceEid);
+	d->sourceEid = MTAKE(eidLen + 1);
+	if (d->sourceEid == NULL)
+	{
+		MRELEASE(d->bytes);
+		MRELEASE(d);
+		return -1;
+	}
+
+	memcpy(d->bytes, bytes, bytesLen);
+	memcpy(d->sourceEid, sourceEid, eidLen + 1);
+	d->bytesLen = bytesLen;
+
+	if (deferredTail == NULL)
+	{
+		deferredHead = d;
+	}
+	else
+	{
+		deferredTail->next = d;
+	}
+
+	deferredTail = d;
+	return 0;
+}
+
+static DeferredBundle *dequeueDeferred(void)
+{
+	DeferredBundle *d = deferredHead;
+
+	if (d == NULL)
+	{
+		return NULL;
+	}
+
+	deferredHead = d->next;
+	if (deferredHead == NULL)
+	{
+		deferredTail = NULL;
+	}
+
+	d->next = NULL;
+	return d;
+}
+
+static void freeDeferred(DeferredBundle *d)
+{
+	if (d == NULL)
+	{
+		return;
+	}
+
+	if (d->bytes)
+	{
+		MRELEASE(d->bytes);
+	}
+
+	if (d->sourceEid)
+	{
+		MRELEASE(d->sourceEid);
+	}
+
+	MRELEASE(d);
+}
+
+/*	The defer callback handed to bpshSessionRun: a session passes us a
+ *	bundle that arrived mid-command but wasn't its own stdin.	*/
+static void deferBundle(void *ctx, unsigned char *bytes, size_t len,
+		const char *srcEid)
+{
+	(void) ctx;
+	if (enqueueDeferred(bytes, len, srcEid) < 0)
+	{
+		writeMemo("[?] bpshd: can't defer bundle; dropping.");
+	}
+}
+
+/*	Session table: linear scan keyed by source EID.  Expects tens of
+ *	sessions max; replace with a hash if scaling demands it.	*/
+static BpshSession *findSession(const char *sourceEid)
+{
+	int i;
+
+	for (i = 0; i < sessionCount; i++)
+	{
+		if (strcmp(bpshSessionEid(sessions[i]), sourceEid) == 0)
+		{
+			return sessions[i];
+		}
+	}
+
+	return NULL;
+}
+
+static int addSession(BpshSession *s)
+{
+	if (sessionCount == sessionCap)
+	{
+		int	      newCap = sessionCap == 0 ? 8 : sessionCap * 2;
+		BpshSession **bigger = MTAKE(newCap * sizeof(BpshSession *));
+
+		if (bigger == NULL)
+		{
+			return -1;
+		}
+
+		if (sessions != NULL)
+		{
+			memcpy(bigger, sessions,
+					sessionCount * sizeof(BpshSession *));
+			MRELEASE(sessions);
+		}
+
+		sessions = bigger;
+		sessionCap = newCap;
+	}
+
+	sessions[sessionCount++] = s;
+	return 0;
+}
+
+/*	Drop s from the table, then close it.				*/
+static void removeSession(BpshSession *s)
+{
+	int i;
+
+	for (i = 0; i < sessionCount; i++)
+	{
+		if (sessions[i] == s)
+		{
+			sessions[i] = sessions[sessionCount - 1];
+			sessionCount--;
+			break;
+		}
+	}
+
+	bpshSessionClose(s);
+}
+
+static void teardownAllSessions(void)
+{
+	int i;
+
+	for (i = 0; i < sessionCount; i++)
+	{
+		bpshSessionClose(sessions[i]);
+	}
+
+	sessionCount = 0;
+	if (sessions != NULL)
+	{
+		MRELEASE(sessions);
+		sessions = NULL;
+		sessionCap = 0;
+	}
+}
+
+static int handleFrame(BpshFrame *frame, char *sourceEid)
+{
+	BpshSession *s;
+	char	    *cmd;
+
+	switch (frame->msgType)
+	{
+	case BpshMsgInit:
+	{
+		int wantStdin = 0;
+		if (frame->payloadLen >= 1 && frame->payload[0] == 0x01)
+		{
+			wantStdin = 1;
+		}
+
+		s = findSession(sourceEid);
+		if (s != NULL)
+		{
+			writeMemoNote("[i] bpshd INIT replaces prior session for",
+					sourceEid);
+			removeSession(s);
+		}
+
+		s = bpshSessionOpen(sap, sourceEid, frame->sessionId, wantStdin);
+		if (s == NULL)
+		{
+			putErrmsg("bpshd: can't open session.", sourceEid);
+			return bpsh_send_error(sap, sourceEid, frame->sessionId,
+					0, "unable to start shell");
+		}
+
+		if (addSession(s) < 0)
+		{
+			putErrmsg("bpshd: can't register session.", sourceEid);
+			bpshSessionClose(s);
+			return bpsh_send_error(sap, sourceEid, frame->sessionId,
+					0, "unable to register session");
+		}
+
+		writeMemoNote(wantStdin ? "[i] bpshd INIT (stdin)" :
+					  "[i] bpshd INIT",
+				sourceEid);
+
+		/*	Send the initial cwd before INIT_ACK (lower seq) so
+		 *	the client's first prompt already shows it.	*/
+		bpshSessionSendCwd(s);
+		return bpsh_send_ctl(sap, sourceEid, BpshMsgInitAck,
+				bpshSessionId(s), bpshSessionNextSeq(s));
+	}
+
+	case BpshMsgReq:
+		s = findSession(sourceEid);
+		if (s == NULL)
+		{
+			return bpsh_send_error(sap, sourceEid, frame->sessionId,
+					0,
+					"session not initialized; send INIT first");
+		}
+
+		if (bpshSessionId(s) != frame->sessionId)
+		{
+			return bpsh_send_error(sap, sourceEid, frame->sessionId,
+					0, "session id mismatch; reinit");
+		}
+
+		if (!bpshSessionAlive(s))
+		{
+			return bpsh_send_error(sap, sourceEid, frame->sessionId,
+					bpshSessionNextSeq(s),
+					"shell exited; reinitialize session");
+		}
+
+		cmd = MTAKE(frame->payloadLen + 1);
+		if (cmd == NULL)
+		{
+			return bpsh_send_exit(sap, sourceEid, frame->sessionId,
+					bpshSessionNextSeq(s), -1,
+					BpshCauseKilled);
+		}
+
+		memcpy(cmd, frame->payload, frame->payloadLen);
+		cmd[frame->payloadLen] = '\0';
+		writeMemoNote("[i] bpshd REQ", cmd);
+		bpshSessionRun(s, cmd, &running, deferBundle, NULL);
+		MRELEASE(cmd);
+
+		if (!bpshSessionAlive(s))
+		{
+			removeSession(s);
+		}
+
+		return 0;
+
+	case BpshMsgExitSession:
+		s = findSession(sourceEid);
+		if (s != NULL)
+		{
+			writeMemoNote("[i] bpshd EXIT_SESSION", sourceEid);
+			removeSession(s);
+		}
+
+		return 0;
+
+	default:
+		writeMemoNote("[?] bpshd unexpected msgType",
+				bpsh_msgtype_name(frame->msgType));
+		return 0;
+	}
+}
+
+/*	Replay one bundle deferred while a command ran.  Returns 1 if a
+ *	deferred bundle was handled (call again), 0 if the queue is empty.*/
+static int drainDeferred(void)
+{
+	DeferredBundle *d;
+	BpshFrame	frame;
+
+	if (deferredHead == NULL)
+	{
+		return 0;
+	}
+
+	d = dequeueDeferred();
+	if (bpsh_decode(d->bytes, d->bytesLen, &frame) >= 0)
+	{
+		handleFrame(&frame, d->sourceEid);
+	}
+
+	freeDeferred(d);
+	return 1;
+}
+
+/*	Receive decoded frames and dispatch them, first replaying any
+ *	bundles deferred while a command was running.			*/
+static int receiveLoop(void)
+{
+	BpshFrame      frame;
+	unsigned char *bytes;
+	size_t	       bytesLen;
+	char	       srcEid[BPSH_MAX_EID];
+	int	       rc;
+
+	while (running)
+	{
+		if (drainDeferred())
+		{
+			continue;
+		}
+
+		rc = bpsh_recv_frame(sap, BP_BLOCKING, BPSHD_RECV_BUFSIZE, &frame,
+				&bytes, &bytesLen, srcEid, sizeof srcEid);
+		if (rc == BPSH_RECV_FATAL)
+		{
+			writeMemo("[i] bpshd receive loop ending.");
+			break;
+		}
+
+		if (rc == BPSH_RECV_NONE || rc == BPSH_RECV_SKIP)
+		{
+			continue;
+		}
+
+		handleFrame(&frame, srcEid);
+		MRELEASE(bytes);
+	}
+
+	return 0;
+}
+
+static void usage(void)
+{
+	fprintf(stderr,
+			"Usage: bpshd <listen EID>\n"
+			"\n"
+			"Listens on <listen EID> for bpsh client requests.  Each\n"
+			"client session gets a persistent /bin/sh; commands are\n"
+			"run inside it (so cd, env-vars persist), and stdout /\n"
+			"stderr / exit-code are returned in separate bundles.\n");
+}
+
+int main(int argc, char **argv)
+{
+	char *listenEid;
+
+	if (argc < 2 || argv[1][0] == '-')
+	{
+		usage();
+		return 1;
+	}
+
+	listenEid = argv[1];
+
+	if (bp_attach() < 0)
+	{
+		putErrmsg("bpshd: bp_attach failed.", NULL);
+		return 1;
+	}
+
+	if (bp_open(listenEid, &sap) < 0)
+	{
+		putErrmsg("bpshd: can't open listen endpoint.", listenEid);
+		bp_detach();
+		return 1;
+	}
+
+	/*	Send command output with flow control: ionCreateZco then
+	 *	blocks for ZCO space instead of failing on large output.	*/
+	if (ionStartAttendant(&attendant) < 0)
+	{
+		putErrmsg("bpshd: can't start transmission attendant.", NULL);
+		bp_close(sap);
+		bp_detach();
+		return 1;
+	}
+
+	attendantStarted = 1;
+	bpsh_set_send_attendant(&attendant);
+
+	signal(SIGINT, handleQuit);
+	signal(SIGTERM, handleQuit);
+	/*	Don't let a closed shell pipe abort the daemon.		*/
+	signal(SIGPIPE, SIG_IGN);
+
+	writeMemoNote("[i] bpshd listening on", listenEid);
+	receiveLoop();
+
+	teardownAllSessions();
+	bpsh_set_send_attendant(NULL);
+	ionStopAttendant(&attendant);
+	bp_close(sap);
+	bp_detach();
+	return 0;
+}

--- a/bpv7/utils/bpshd_session.c
+++ b/bpv7/utils/bpshd_session.c
@@ -1,0 +1,722 @@
+/*
+ * bpshd_session.c: one bpshd shell session (see bpshd_session.h).
+ *
+ * A session is a persistent /bin/sh child whose stdin/stdout/stderr are
+ * wired to pipes the daemon owns, plus a pipe at child fd 3 carrying
+ * forwarded user stdin and a control pipe at child fd 4.  Each command
+ * runs as "{ cmd ; } <&3 4>&-" (or a subshell when forwarding stdin),
+ * then echoes its exit status ($?) to fd 4.  The daemon streams the
+ * shell's stdout/stderr verbatim (no in-band markers, no holdback) and
+ * treats the exit code arriving on fd 4 as the command boundary: once
+ * it reads the rc line, it drains any remaining stdout/stderr and
+ * reports EXIT.  (All of the command's output is in the pipes before
+ * the shell writes the rc, since those writes are sequenced after the
+ * command has exited and flushed.)
+ */
+
+#include <bp.h>
+#include <sys/select.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "bpsh_proto.h"
+#include "bpshd_session.h"
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define BPSHD_OUTPUT_LIMIT  (16 * 1024 * 1024)
+#define BPSHD_READ_CHUNK    (16 * 1024)
+/*	Cap on a single output bundle's payload, so one bundle always fits
+ *	the outbound ZCO budget (which the attendant blocks against).	*/
+#define BPSHD_MAX_PAYLOAD   (16 * 1024)
+/*	Default wall-clock limit for a single command before it (and its
+ *	shell) is killed; overridable via env BPSHD_CMD_TIMEOUT (seconds,
+ *	0 disables).							*/
+#define BPSHD_CMD_TIMEOUT_MS (300 * 1000)
+
+struct BpshSession
+{
+	BpSAP sap;	    /* endpoint replies are sent on		*/
+	char *sourceEid;
+	uvast sessionId;
+
+	pid_t shellPid;
+	int   stdinFd;	    /* parent writes commands here  (child fd 0)	*/
+	int   stdoutFd;	    /* parent reads child stdout    (child fd 1)	*/
+	int   stderrFd;	    /* parent reads child stderr    (child fd 2)	*/
+	int   userStdinFd;  /* parent writes user stdin   -> child fd 3	*/
+	int   ctlFd;	    /* parent reads exit codes from  child fd 4	*/
+	int   userStdinReq; /* client requested stdin forwarding (INIT)	*/
+
+	uvast replySeq;	    /* per-session monotonic outbound seq		*/
+	int   shellAlive;
+};
+
+static void closeFd(int *fd)
+{
+	if (*fd >= 0)
+	{
+		close(*fd);
+		*fd = -1;
+	}
+}
+
+BpshSession *bpshSessionOpen(BpSAP sap, const char *sourceEid, uvast sessionId,
+		int wantStdin)
+{
+	BpshSession *s;
+	int	     inPipe[2] = { -1, -1 };
+	int	     outPipe[2] = { -1, -1 };
+	int	     errPipe[2] = { -1, -1 };
+	int	     dataPipe[2] = { -1, -1 };
+	int	     ctlPipe[2] = { -1, -1 };
+	pid_t	     pid;
+	size_t	     eidLen;
+
+	if (pipe(inPipe) < 0)
+	{
+		goto fail;
+	}
+
+	if (pipe(outPipe) < 0)
+	{
+		goto fail;
+	}
+
+	if (pipe(errPipe) < 0)
+	{
+		goto fail;
+	}
+
+	if (pipe(dataPipe) < 0)
+	{
+		goto fail;
+	}
+
+	if (pipe(ctlPipe) < 0)
+	{
+		goto fail;
+	}
+
+	pid = fork();
+	if (pid < 0)
+	{
+		goto fail;
+	}
+
+	if (pid == 0)
+	{
+		/*	Child: wire pipes to fd 0/1/2, the user-stdin pipe to
+		 *	fd 3 (read via "<&3"), and the control pipe to fd 4
+		 *	(exit codes written via ">&4").  Not interactive: we
+		 *	drive it by writing commands plus an rc printf.	*/
+		dup2(inPipe[0], 0);
+		dup2(outPipe[1], 1);
+		dup2(errPipe[1], 2);
+		dup2(dataPipe[0], 3);
+		dup2(ctlPipe[1], 4);
+		close(inPipe[0]);
+		close(inPipe[1]);
+		close(outPipe[0]);
+		close(outPipe[1]);
+		close(errPipe[0]);
+		close(errPipe[1]);
+		close(dataPipe[0]);
+		close(dataPipe[1]);
+		close(ctlPipe[0]);
+		close(ctlPipe[1]);
+		/*	Lead our own process group so a later kill(-pgid)
+		 *	tears down the shell and whatever command it's
+		 *	running together (used to abort a stalled command
+		 *	when the client reconnects).			*/
+		setpgid(0, 0);
+		execl("/bin/sh", "sh", (char *) NULL);
+		_exit(127);
+	}
+
+	/*	Parent: keep the ends we'll use, close the rest.	*/
+	close(inPipe[0]);
+	close(outPipe[1]);
+	close(errPipe[1]);
+	close(dataPipe[0]);
+	close(ctlPipe[1]);
+
+	/*	If client did not request stdin forwarding, close our
+	 *	write end so the child sees EOF on fd 3 immediately
+	 *	(prevents stdin-reading commands from hanging in REPL).	*/
+	if (!wantStdin)
+	{
+		close(dataPipe[1]);
+		dataPipe[1] = -1;
+	}
+
+	s = MTAKE(sizeof(BpshSession));
+	if (s == NULL)
+	{
+		kill(pid, SIGKILL);
+		waitpid(pid, NULL, 0);
+		close(inPipe[1]);
+		close(outPipe[0]);
+		close(errPipe[0]);
+		close(ctlPipe[0]);
+		if (dataPipe[1] >= 0)
+		{
+			close(dataPipe[1]);
+		}
+
+		return NULL;
+	}
+
+	memset(s, 0, sizeof(*s));
+	eidLen = strlen(sourceEid);
+	s->sourceEid = MTAKE(eidLen + 1);
+	if (s->sourceEid == NULL)
+	{
+		MRELEASE(s);
+		kill(pid, SIGKILL);
+		waitpid(pid, NULL, 0);
+		close(inPipe[1]);
+		close(outPipe[0]);
+		close(errPipe[0]);
+		close(ctlPipe[0]);
+		if (dataPipe[1] >= 0)
+		{
+			close(dataPipe[1]);
+		}
+
+		return NULL;
+	}
+
+	/*	Read stdout/stderr non-blocking so we can drain them to
+	 *	empty once the command's rc arrives on the control pipe.	*/
+	oK(fcntl(outPipe[0], F_SETFL, O_NONBLOCK));
+	oK(fcntl(errPipe[0], F_SETFL, O_NONBLOCK));
+
+	memcpy(s->sourceEid, sourceEid, eidLen + 1);
+	s->sap = sap;
+	s->sessionId = sessionId;
+	s->shellPid = pid;
+	s->stdinFd = inPipe[1];
+	s->stdoutFd = outPipe[0];
+	s->stderrFd = errPipe[0];
+	s->userStdinFd = dataPipe[1];
+	s->ctlFd = ctlPipe[0];
+	s->userStdinReq = wantStdin ? 1 : 0;
+	s->replySeq = 0;
+	s->shellAlive = 1;
+	return s;
+
+fail:
+	if (inPipe[0] >= 0)
+		close(inPipe[0]);
+	if (inPipe[1] >= 0)
+		close(inPipe[1]);
+	if (outPipe[0] >= 0)
+		close(outPipe[0]);
+	if (outPipe[1] >= 0)
+		close(outPipe[1]);
+	if (errPipe[0] >= 0)
+		close(errPipe[0]);
+	if (errPipe[1] >= 0)
+		close(errPipe[1]);
+	if (dataPipe[0] >= 0)
+		close(dataPipe[0]);
+	if (dataPipe[1] >= 0)
+		close(dataPipe[1]);
+	if (ctlPipe[0] >= 0)
+		close(ctlPipe[0]);
+	if (ctlPipe[1] >= 0)
+		close(ctlPipe[1]);
+	return NULL;
+}
+
+void bpshSessionClose(BpshSession *s)
+{
+	int i;
+	int status;
+
+	if (s == NULL)
+	{
+		return;
+	}
+
+	closeFd(&s->stdinFd);
+	closeFd(&s->stdoutFd);
+	closeFd(&s->stderrFd);
+	closeFd(&s->userStdinFd);
+	closeFd(&s->ctlFd);
+
+	if (s->shellPid > 0)
+	{
+		kill(s->shellPid, SIGTERM);
+		/*	Brief wait, then SIGKILL if still alive.	*/
+		for (i = 0; i < 50; i++)
+		{
+			if (waitpid(s->shellPid, &status, WNOHANG) != 0)
+			{
+				goto reaped;
+			}
+
+			usleep(20000);
+		}
+
+		kill(s->shellPid, SIGKILL);
+		waitpid(s->shellPid, &status, 0);
+	}
+
+reaped:
+	MRELEASE(s->sourceEid);
+	MRELEASE(s);
+}
+
+void bpshSessionSendCwd(BpshSession *s)
+{
+	char	proc[64];
+	char	path[PATH_MAX];
+	ssize_t n;
+
+	/*	The shell process's cwd reflects any "cd" it has run.  Read
+	 *	it via /proc (Linux: .../cwd; Solaris: .../path/cwd).  If
+	 *	neither is available, silently skip -- the client just
+	 *	won't show a path.					*/
+	isprintf(proc, sizeof proc, "/proc/%d/cwd", (int) s->shellPid);
+	n = readlink(proc, path, sizeof path - 1);
+	if (n < 0)
+	{
+		isprintf(proc, sizeof proc, "/proc/%d/path/cwd",
+				(int) s->shellPid);
+		n = readlink(proc, path, sizeof path - 1);
+	}
+
+	if (n < 0)
+	{
+		return;
+	}
+
+	path[n] = '\0';
+	bpsh_send_bytes(s->sap, s->sourceEid, BpshMsgCwd, s->sessionId,
+			s->replySeq++, (unsigned char *) path, (size_t) n);
+}
+
+/*	writeAll: write the full buffer or fail.  Returns 0 on success,
+ *	-1 on error (including EPIPE if the shell died).		*/
+static int writeAll(int fd, const char *buf, size_t len)
+{
+	while (len > 0)
+	{
+		ssize_t n = write(fd, buf, len);
+		if (n < 0)
+		{
+			if (errno == EINTR)
+			{
+				continue;
+			}
+
+			return -1;
+		}
+
+		buf += n;
+		len -= (size_t) n;
+	}
+
+	return 0;
+}
+
+/*	Monotonic clock, milliseconds, for the command timeout.	*/
+static long monoMs(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (long) (ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+/*	While a command is running we still need to service incoming
+ *	bundles -- STDIN_CHUNK / STDIN_EOF for this session are handled
+ *	inline (written to / closed on userStdinFd); anything else is
+ *	handed to the daemon's defer callback for replay once the command
+ *	returns.							*/
+static int pollIncoming(BpshSession *s, const int *running, BpshDeferFn defer,
+		void *ctx)
+{
+	while (*running)
+	{
+		BpshFrame      frame;
+		unsigned char *bytes;
+		size_t	       bytesLen;
+		char	       srcEid[BPSH_MAX_EID];
+		int	       rc;
+
+		rc = bpsh_recv_frame(s->sap, BP_POLL, BPSHD_RECV_BUFSIZE, &frame,
+				&bytes, &bytesLen, srcEid, sizeof srcEid);
+		if (rc == BPSH_RECV_FATAL)
+		{
+			return -1;
+		}
+
+		if (rc == BPSH_RECV_NONE)
+		{
+			return 0;
+		}
+
+		if (rc == BPSH_RECV_SKIP)
+		{
+			continue;
+		}
+
+		/*	Inline handling for stdin frames belonging to this
+		 *	session.					*/
+		if (frame.sessionId == s->sessionId
+				&& strcmp(srcEid, s->sourceEid) == 0)
+		{
+			if (frame.msgType == BpshMsgStdinChunk)
+			{
+				if (s->userStdinFd >= 0 && frame.payloadLen > 0)
+				{
+					if (writeAll(s->userStdinFd,
+							    (const char *) frame.payload,
+							    frame.payloadLen)
+							< 0)
+					{
+						closeFd(&s->userStdinFd);
+					}
+				}
+
+				MRELEASE(bytes);
+				continue;
+			}
+
+			if (frame.msgType == BpshMsgStdinEof)
+			{
+				closeFd(&s->userStdinFd);
+				MRELEASE(bytes);
+				continue;
+			}
+		}
+
+		/*	A fresh INIT from the same client while a command is
+		 *	still running here means the client is reconnecting --
+		 *	typically to recover from a stalled command.  Kill the
+		 *	shell's process group so this runCommand unwinds; the
+		 *	INIT, deferred below, then replaces the session.	*/
+		if (frame.msgType == BpshMsgInit
+				&& strcmp(srcEid, s->sourceEid) == 0
+				&& s->shellPid > 0)
+		{
+			kill(-s->shellPid, SIGKILL);
+		}
+
+		/*	Anything else is the daemon's to route.		*/
+		if (defer != NULL)
+		{
+			defer(ctx, bytes, bytesLen, srcEid);
+		}
+
+		MRELEASE(bytes);
+	}
+
+	return -1;
+}
+
+/*	Send buf[0..len) to the client as one or more frames of the given
+ *	type, each no larger than BPSHD_MAX_PAYLOAD.  The sequence number
+ *	is advanced only after a frame is actually sent, so a failed send
+ *	never leaves a gap that would stall the client's in-order reorder
+ *	buffer.  Returns 0 if all bytes were sent, -1 otherwise.	*/
+static int sendStream(BpshSession *s, BpshMsgType type, unsigned char *buf,
+		size_t len)
+{
+	size_t off = 0;
+
+	while (off < len)
+	{
+		size_t n = len - off;
+
+		if (n > BPSHD_MAX_PAYLOAD)
+		{
+			n = BPSHD_MAX_PAYLOAD;
+		}
+
+		if (bpsh_send_bytes(s->sap, s->sourceEid, type, s->sessionId,
+				    s->replySeq, buf + off, n)
+				< 0)
+		{
+			return -1;
+		}
+
+		s->replySeq++;
+		off += n;
+	}
+
+	return 0;
+}
+
+/*	Read all currently-available bytes from a non-blocking fd and
+ *	stream them to the client.  Called once a command's rc has arrived
+ *	to flush whatever output is still buffered in the pipe -- the
+ *	command has exited, so the pipe holds exactly the remaining output
+ *	and nothing more.  Returns 0, or -1 on send error.		*/
+static int drainStream(BpshSession *s, int fd, BpshMsgType type)
+{
+	unsigned char chunk[BPSHD_READ_CHUNK];
+	ssize_t	      r;
+
+	while ((r = read(fd, chunk, sizeof chunk)) > 0)
+	{
+		if (sendStream(s, type, chunk, (size_t) r) < 0)
+		{
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+/*	Per-command wall-clock timeout in ms (0 = disabled).  Read once
+ *	from BPSHD_CMD_TIMEOUT (seconds), else the compiled-in default.	*/
+static long cmdTimeoutMs(void)
+{
+	static int  inited = 0;
+	static long ms = BPSHD_CMD_TIMEOUT_MS;
+
+	if (!inited)
+	{
+		const char *e = getenv("BPSHD_CMD_TIMEOUT");
+
+		if (e != NULL)
+		{
+			ms = atol(e) * 1000;	/* 0 or negative disables	*/
+		}
+
+		inited = 1;
+	}
+
+	return ms;
+}
+
+/*	Kill the session's process group (command + shell) and mark it
+ *	dead -- used for the timeout and output-cap.			*/
+static void killSession(BpshSession *s, BpshExitCause *cause, BpshExitCause why)
+{
+	if (s->shellPid > 0)
+	{
+		kill(-s->shellPid, SIGKILL);
+	}
+
+	s->shellAlive = 0;
+	*cause = why;
+}
+
+int bpshSessionRun(BpshSession *s, const char *cmdline, const int *running,
+		BpshDeferFn defer, void *ctx)
+{
+	char	      *postscript;
+	size_t	       postCap;
+	int	       postLen;
+	int	       exitCode = 0;
+	BpshExitCause  cause = BpshCauseNormal;
+	int	       outEof = 0, errEof = 0;
+	char	       ctlBuf[32];
+	size_t	       ctlLen = 0;
+	size_t	       totalOut = 0;
+	long	       cmdStartMs;
+	const char    *cmdOpen;
+	const char    *cmdClose;
+
+	postCap = strlen(cmdline) + 256;
+	postscript = MTAKE(postCap);
+	if (postscript == NULL)
+	{
+		return bpsh_send_exit(s->sap, s->sourceEid, s->sessionId,
+				s->replySeq++, -1, BpshCauseKilled);
+	}
+
+	/*	Run the command with stdin from the user-stdin pipe (fd 3)
+	 *	and the control pipe (fd 4) closed; snapshot its exit code,
+	 *	echo it to fd 4, then restore $? via "(exit $rc)" so the
+	 *	next command's first "$?" still sees the original code (the
+	 *	echo would otherwise have reset it to 0).  "{ ...; }" in
+	 *	REPL sessions so cd/export persist; "( ... )" (a subshell)
+	 *	when forwarding stdin, so a user "exit N" ends only the
+	 *	subshell, not the driver shell.				*/
+	cmdOpen = s->userStdinReq ? "( " : "{ ";
+	cmdClose = s->userStdinReq ? " ) <&3 4>&-" : " ; } <&3 4>&-";
+	postLen = _isprintf(postscript, postCap,
+			"%s%s%s\n"
+			"__bpsh_rc=$?\n"
+			"echo \"$__bpsh_rc\" >&4\n"
+			"(exit $__bpsh_rc)\n",
+			cmdOpen, cmdline, cmdClose);
+	if (postLen <= 0 || writeAll(s->stdinFd, postscript, (size_t) postLen) < 0)
+	{
+		MRELEASE(postscript);
+		s->shellAlive = 0;
+		return bpsh_send_exit(s->sap, s->sourceEid, s->sessionId,
+				s->replySeq++, -1, BpshCauseKilled);
+	}
+
+	MRELEASE(postscript);
+
+	cmdStartMs = monoMs();
+
+	while (1)
+	{
+		fd_set	       rfds;
+		int	       maxFd = -1;
+		int	       nready;
+		long	       now;
+		struct timeval tv;
+		unsigned char  chunk[BPSHD_READ_CHUNK];
+		ssize_t	       r;
+
+		FD_ZERO(&rfds);
+		FD_SET(s->stdoutFd, &rfds);
+		maxFd = s->stdoutFd;
+		FD_SET(s->stderrFd, &rfds);
+		if (s->stderrFd > maxFd)
+		{
+			maxFd = s->stderrFd;
+		}
+
+		if (s->ctlFd >= 0)
+		{
+			FD_SET(s->ctlFd, &rfds);
+			if (s->ctlFd > maxFd)
+			{
+				maxFd = s->ctlFd;
+			}
+		}
+
+		/*	Wake at least every 100 ms to poll BP and re-check
+		 *	the wall-clock timeout.				*/
+		tv.tv_sec = 0;
+		tv.tv_usec = 100 * 1000;
+		nready = select(maxFd + 1, &rfds, NULL, NULL, &tv);
+		if (nready < 0)
+		{
+			if (errno == EINTR)
+			{
+				continue;
+			}
+
+			s->shellAlive = 0;
+			cause = BpshCauseKilled;
+			break;
+		}
+
+		now = monoMs();
+		if (cmdTimeoutMs() > 0 && now - cmdStartMs >= cmdTimeoutMs())
+		{
+			killSession(s, &cause, BpshCauseTimeout);
+			break;
+		}
+
+		/*	Stream stdout/stderr verbatim as it arrives.	*/
+		if (FD_ISSET(s->stdoutFd, &rfds))
+		{
+			r = read(s->stdoutFd, chunk, sizeof chunk);
+			if (r > 0)
+			{
+				sendStream(s, BpshMsgStdout, chunk, (size_t) r);
+				totalOut += (size_t) r;
+			}
+			else if (r == 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
+			{
+				outEof = 1;
+			}
+		}
+
+		if (FD_ISSET(s->stderrFd, &rfds))
+		{
+			r = read(s->stderrFd, chunk, sizeof chunk);
+			if (r > 0)
+			{
+				sendStream(s, BpshMsgStderr, chunk, (size_t) r);
+				totalOut += (size_t) r;
+			}
+			else if (r == 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
+			{
+				errEof = 1;
+			}
+		}
+
+		if (totalOut > BPSHD_OUTPUT_LIMIT)
+		{
+			killSession(s, &cause, BpshCauseOutputLimit);
+			break;
+		}
+
+		/*	The command's exit code arriving on fd 4 is the
+		 *	command boundary.				*/
+		if (s->ctlFd >= 0 && FD_ISSET(s->ctlFd, &rfds))
+		{
+			r = read(s->ctlFd, ctlBuf + ctlLen,
+					sizeof ctlBuf - 1 - ctlLen);
+			if (r > 0)
+			{
+				ctlLen += (size_t) r;
+				ctlBuf[ctlLen] = '\0';
+				if (memchr(ctlBuf, '\n', ctlLen) != NULL)
+				{
+					exitCode = (int) strtol(ctlBuf, NULL, 10);
+					break;
+				}
+			}
+			else if (r == 0)
+			{
+				closeFd(&s->ctlFd);
+			}
+		}
+
+		/*	Both data streams closing without an rc means the
+		 *	driver shell itself exited (e.g. the user ran "exit").	*/
+		if (outEof && errEof)
+		{
+			s->shellAlive = 0;
+			cause = BpshCauseKilled;
+			break;
+		}
+
+		/*	Service stdin / interrupt / reconnect bundles.	*/
+		pollIncoming(s, running, defer, ctx);
+	}
+
+	/*	Drain whatever output is still buffered in the pipes (the
+	 *	command's writes all precede its rc, so this captures the
+	 *	rest), then report EXIT.				*/
+	drainStream(s, s->stdoutFd, BpshMsgStdout);
+	drainStream(s, s->stderrFd, BpshMsgStderr);
+
+	/*	Report the (possibly changed) cwd before EXIT so the client
+	 *	can refresh its prompt.  Skipped if the shell has died.	*/
+	if (s->shellAlive)
+	{
+		bpshSessionSendCwd(s);
+	}
+
+	return bpsh_send_exit(s->sap, s->sourceEid, s->sessionId, s->replySeq++,
+			exitCode, cause);
+}
+
+const char *bpshSessionEid(const BpshSession *s)
+{
+	return s->sourceEid;
+}
+
+uvast bpshSessionId(const BpshSession *s)
+{
+	return s->sessionId;
+}
+
+int bpshSessionAlive(const BpshSession *s)
+{
+	return s->shellAlive;
+}
+
+uvast bpshSessionNextSeq(BpshSession *s)
+{
+	return s->replySeq++;
+}

--- a/bpv7/utils/bpshd_session.h
+++ b/bpv7/utils/bpshd_session.h
@@ -1,0 +1,73 @@
+/*
+ * bpshd_session.h: one bpshd shell session.
+ *
+ * A BpshSession is a single client's persistent /bin/sh: a fork()ed
+ * shell whose stdin/stdout/stderr the daemon owns, plus a fd-3 pipe
+ * for forwarded user stdin and a fd-4 control pipe carrying each
+ * command's exit code.  This module is purely the per-session
+ * object -- open it, run command lines on it, close it.  The daemon
+ * (bpshd.c) owns the collection of sessions, the routing of frames to
+ * them, and the queue of bundles deferred while a command runs.
+ *
+ * While a command runs, the session keeps the shared BP endpoint
+ * serviced so its own forwarded-stdin bundles flow; any bundle that
+ * isn't this session's stdin is handed to the daemon-supplied defer
+ * callback rather than being routed here.
+ */
+
+#ifndef BPSHD_SESSION_H
+#define BPSHD_SESSION_H
+
+#include "bpsh_proto.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*	Largest bundle the daemon will accept (also the cap passed to
+ *	bpsh_recv_frame by both the main loop and a running session).	*/
+#define BPSHD_RECV_BUFSIZE (64 * 1024)
+
+typedef struct BpshSession BpshSession;
+
+/*	Callback the daemon supplies to bpshSessionRun so a bundle that
+ *	arrived mid-command but isn't this session's stdin can be handed
+ *	back for the daemon to queue.  The bytes are owned by the caller;
+ *	the callback must copy anything it keeps.			*/
+typedef void (*BpshDeferFn)(void *ctx, unsigned char *bytes, size_t len,
+		const char *srcEid);
+
+/*	bpshSessionOpen: fork a /bin/sh and wire up its pipes.  sap is the
+ *	endpoint replies are sent on.  wantStdin keeps the fd-3 stdin pipe
+ *	open for forwarding.  Returns NULL on failure.			*/
+extern BpshSession *bpshSessionOpen(BpSAP sap, const char *sourceEid,
+		uvast sessionId, int wantStdin);
+
+/*	bpshSessionClose: terminate the shell, close fds, free.		*/
+extern void bpshSessionClose(BpshSession *s);
+
+/*	bpshSessionSendCwd: read the shell's current working directory and
+ *	send it to the client as a CWD frame.  No-op if the cwd can't be
+ *	determined (e.g. no /proc).  Sent at INIT and after each command
+ *	so the client can show it in the prompt.			*/
+extern void bpshSessionSendCwd(BpshSession *s);
+
+/*	bpshSessionRun: run one command line in the session's shell,
+ *	streaming STDOUT / STDERR / EXIT back to the client.  While it
+ *	runs, the session services its own forwarded-stdin bundles off
+ *	sap; any other bundle is passed to defer(ctx, ...).  *running is
+ *	polled so a shutdown request can unwind the poll.  Returns 0.	*/
+extern int bpshSessionRun(BpshSession *s, const char *cmdline,
+		const int *running, BpshDeferFn defer, void *ctx);
+
+/*	Accessors the daemon needs for routing and validation.		*/
+extern const char *bpshSessionEid(const BpshSession *s);
+extern uvast	   bpshSessionId(const BpshSession *s);
+extern int	   bpshSessionAlive(const BpshSession *s);
+extern uvast	   bpshSessionNextSeq(BpshSession *s); /* returns, then ++	*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BPSHD_SESSION_H */

--- a/bpv7/x86_64-linux/Makefile.dev
+++ b/bpv7/x86_64-linux/Makefile.dev
@@ -123,7 +123,7 @@ endif
 
 LBP = -lbp $(LBSL)
 
-RUNTIMES_BASE = bpadmin bpsink bpsource bpdriver bpecho bpcounter bpsendfile bprecvfile bpsendtest bprecvtest bpclock bptransit bpclm ipnadmin ipnfw ipnadminep dtn2admin dtn2fw dtn2adminep tcpcli tcpclo stcpcli stcpclo brsscla brsccla udpcli udpclo sppcli sppclo dgrcli dgrclo ltpcli ltpclo lgsend lgagent bptrace bpstats bplist bpcancel hmackeys bping bpstats2 bpchat imcfw imcadminep bsspcli bsspclo bibeclo bibeadmin bpnmtest ipnd cgrfetch bpcrash bpcrash_hard bpinspect cpsd sendfile recvfile bptracker
+RUNTIMES_BASE = bpadmin bpsink bpsource bpdriver bpecho bpcounter bpsendfile bprecvfile bpsendtest bprecvtest bpclock bptransit bpclm ipnadmin ipnfw ipnadminep dtn2admin dtn2fw dtn2adminep tcpcli tcpclo stcpcli stcpclo brsscla brsccla udpcli udpclo sppcli sppclo dgrcli dgrclo ltpcli ltpclo lgsend lgagent bptrace bpstats bplist bpcancel hmackeys bping bpstats2 bpchat bpsh bpshd imcfw imcadminep bsspcli bsspclo bibeclo bibeadmin bpnmtest ipnd cgrfetch bpcrash bpcrash_hard bpinspect cpsd sendfile recvfile bptracker
 
 ifeq ($(USING_BSL),1)
 RUNTIMES = $(RUNTIMES_BASE)
@@ -424,6 +424,14 @@ bpsendfile:	bpsendfile.o libbp.so $(BPLIBS)
 bpsendtest:	bpsendtest.o libbp.so $(BPLIBS)
 		$(CC) -o bpsendtest bpsendtest.o -L./lib -L$(ROOT)/lib $(LBP) -lici -lpthread -lm
 		cp bpsendtest ./bin
+
+bpsh:		bpsh.o bpsh_proto.o libbp.so $(BPLIBS)
+		$(CC) -o bpsh bpsh.o bpsh_proto.o -L./lib -L$(ROOT)/lib $(LBP) -lici -lpthread -lm
+		cp bpsh ./bin
+
+bpshd:		bpshd.o bpsh_proto.o libbp.so $(BPLIBS)
+		$(CC) -o bpshd bpshd.o bpsh_proto.o -L./lib -L$(ROOT)/lib $(LBP) -lici -lpthread -lm
+		cp bpshd ./bin
 
 bprecvfile:	bprecvfile.o libbp.so $(BPLIBS)
 		$(CC) -o bprecvfile bprecvfile.o -L./lib -L$(ROOT)/lib $(LBP) -lici -lpthread -lm

--- a/tests/bpsh-loopback/cleanup
+++ b/tests/bpsh-loopback/cleanup
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+killm f >/dev/null 2>&1
+pkill -f "bpshd ipn:1.22" >/dev/null 2>&1
+rm -f ion.log bpshd.log bpshd.pid \
+	out.case1 err.case1 \
+	out.case2 err.case2 \
+	out.case3 err.case3 \
+	out.case4 err.case4 \
+	out.case5 err.case5

--- a/tests/bpsh-loopback/config/host1.rc
+++ b/tests/bpsh-loopback/config/host1.rc
@@ -1,0 +1,46 @@
+## begin ionadmin
+
+# Initialization: node 1, default sdr config.
+1 1 ''
+
+# Start ION node.
+s
+
+# Single-node loopback contact / range.
+a contact +1 +3600 1 1 100000
+a range +1 +3600 1 1 1
+
+# Production / consumption rates.
+m production 1000000
+m consumption 1000000
+
+# Disable congestion forecasting for the test.
+m horizon +0
+## end ionadmin
+
+## begin bpadmin
+
+1
+
+a scheme ipn 'ipnfw' 'ipnadminep'
+
+# bpshd listen endpoint, plus client endpoints used by the test cases.
+a endpoint ipn:1.0   q
+a endpoint ipn:1.22  q
+a endpoint ipn:1.500 q
+a endpoint ipn:1.501 q
+a endpoint ipn:1.502 q
+a endpoint ipn:1.503 q
+a endpoint ipn:1.504 q
+a endpoint ipn:1.505 q
+
+a protocol udp 1400 100
+a induct   udp 127.0.0.1:4556 udpcli
+a outduct  udp 127.0.0.1:4556 'udpclo 2'
+
+s
+## end bpadmin
+
+## begin ipnadmin
+a plan 1 udp/127.0.0.1:4556
+## end ipnadmin

--- a/tests/bpsh-loopback/config/host1.rc
+++ b/tests/bpsh-loopback/config/host1.rc
@@ -33,6 +33,9 @@ a endpoint ipn:1.502 q
 a endpoint ipn:1.503 q
 a endpoint ipn:1.504 q
 a endpoint ipn:1.505 q
+a endpoint ipn:1.513 q
+a endpoint ipn:1.514 q
+a endpoint ipn:1.515 q
 
 a protocol udp 1400 100
 a induct   udp 127.0.0.1:4556 udpcli

--- a/tests/bpsh-loopback/dotest
+++ b/tests/bpsh-loopback/dotest
@@ -223,6 +223,200 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# Case 6: real rsync over bpsh -- use bpsh as rsync's remote shell (-e).
+# bpsh forwards stdin (streaming) and returns stdout/stderr, so one -c
+# invocation is a full-duplex channel that rsync's protocol runs over.
+# Sync a 4-file local dir onto a 2-file remote dir: one identical, one
+# changed, and two new (missing on the remote).  With --checksum, rsync
+# generates the file list and transfers only the content that differs or is
+# missing.  Asserts:
+#   (a) the remote dir becomes identical to the local dir,
+#   (b) rsync skipped the unchanged file and sent only changed + new.
+#
+# NOT FOR LIVE/DTN USE: this case proves bpsh *can* carry rsync, but rsync's
+# interactive protocol is O(files) chatty -- this sync costs ~36+ bundle
+# round-trips each way (see the measurement printed below) even with
+# -W --no-i-r.  Over a real delay-tolerant link that is impractical; use the
+# two-roundtrip approach in Case 7 instead.  Kept only as a feasibility/
+# correctness check of bpsh as a full-duplex transport.
+# ----------------------------------------------------------------------
+echo
+echo "Case 6: real rsync over bpsh (feasibility only -- NOT for live/DTN use,"
+echo "        O(files)-chatty; see Case 7 for the two-roundtrip approach)"
+CASE6_FAIL=0
+if ! command -v rsync >/dev/null 2>&1; then
+	echo "  rsync not installed -- skipping Case 6"
+else
+	LDIR=/tmp/bpsh-rsync-local.$$
+	RDIR=/tmp/bpsh-rsync-remote.$$
+	RSH=/tmp/bpsh-rsh.$$
+	rm -rf "$LDIR" "$RDIR"; mkdir -p "$LDIR" "$RDIR"
+
+	# Local source: 4 files.  Remote (stale): 2 files (same + older); the two
+	# "added" files are missing on the remote and must be created there.
+	printf 'identical contents\n'      > "$LDIR/same.txt"
+	printf 'NEW version of the file\n' > "$LDIR/changed.txt"
+	printf 'a brand-new file\n'        > "$LDIR/added.txt"
+	printf 'another brand-new file\n'  > "$LDIR/added2.txt"
+	printf 'identical contents\n'      > "$RDIR/same.txt"
+	printf 'OLD version of the file\n' > "$RDIR/changed.txt"
+
+	# rsync remote-shell wrapper: drop the host arg rsync passes, then run
+	# the remote rsync command over bpsh's one-shot full-duplex channel.
+	{
+		echo '#!/bin/sh'
+		echo 'shift'
+		echo 'exec bpsh -h ipn:1.22 -l ipn:1.513 -c "$*"'
+	} > "$RSH"
+	chmod +x "$RSH"
+
+	# Snapshot ION's BP bundle counters around the sync to report its cost.
+	# One bpstats dump gives a consistent xmt+rcv pair ("(+) N M" = cumulative
+	# count N, bytes M); loopback counts both directions of every bundle.
+	bpsnap() { bpstats >/dev/null 2>&1; sleep 1; tail -40 ion.log; }
+	bpval()  { echo "$1" | grep "\[x\] $2 " | tail -1 | sed -E 's/.*\(\+\) ([0-9]+) ([0-9]+).*/\1 \2/'; }
+	S=$(bpsnap); read XC0 XB0 <<< "$(bpval "$S" xmt)"; read RC0 RB0 <<< "$(bpval "$S" rcv)"
+
+	# -r recursive, -c checksum (content/hash based, not mtime), -i itemize,
+	# -W whole-file (skip the per-file block-delta checksum negotiation),
+	# --no-i-r send the whole file list in one pass.  Both trim rsync's
+	# protocol chatter, which matters since each frame is a separate bundle.
+	timeout 60 rsync -rciW --no-i-r -e "$RSH" "$LDIR/" "bpshd:$RDIR/" \
+		> rsync.case6 2> rsync.err.case6
+	RC6=$?
+
+	S=$(bpsnap); read XC1 XB1 <<< "$(bpval "$S" xmt)"; read RC1 RB1 <<< "$(bpval "$S" rcv)"
+	echo "  bundles over bpsh for this sync: sent=$((XC1 - XC0)) recv=$((RC1 - RC0))" \
+	     "(bytes tx=$((XB1 - XB0)) rx=$((RB1 - RB0)))"
+
+	if [ "$RC6" -ne 0 ]; then
+		echo "  rsync over bpsh failed (rc=$RC6)"
+		echo "  --- rsync.err.case6 ---"; cat rsync.err.case6
+		CASE6_FAIL=1
+	fi
+	# (a) remote dir identical to local dir.
+	if ! diff -r "$LDIR" "$RDIR" >/dev/null 2>&1; then
+		echo "  remote dir not identical to local after rsync"
+		diff -r "$LDIR" "$RDIR"
+		CASE6_FAIL=1
+	fi
+	# (b) only changed + new transferred; the identical file was skipped.
+	if grep -q " same.txt$" rsync.case6; then
+		echo "  unchanged same.txt was transferred (checksum diff failed)"
+		CASE6_FAIL=1
+	fi
+	grep -q "changed.txt$" rsync.case6 || { echo "  changed.txt not transferred"; CASE6_FAIL=1; }
+	grep -q "added.txt$"   rsync.case6 || { echo "  added.txt not transferred";   CASE6_FAIL=1; }
+	grep -q "added2.txt$"  rsync.case6 || { echo "  added2.txt not transferred";  CASE6_FAIL=1; }
+
+	rm -rf "$LDIR" "$RDIR" "$RSH"
+
+	if [ $CASE6_FAIL -eq 0 ]; then
+		echo "  Case 6 PASS"
+	else
+		echo "  Case 6 FAIL"
+		echo "  --- rsync.case6 (itemized) ---"; cat rsync.case6
+		FAIL=1
+	fi
+fi
+
+# ----------------------------------------------------------------------
+# Case 7: two-roundtrip directory sync over bpsh (rsync reimplemented with a
+# SHA-256 manifest).  Unlike Case 6 this is suitable for a delay-tolerant
+# link: it costs EXACTLY TWO request/response exchanges regardless of how
+# many files there are.
+#   Roundtrip 1: pull the remote dir's per-file SHA-256 manifest.
+#                (diff locally: a file missing remotely or with a different
+#                 hash must be sent)
+#   Roundtrip 2: ship all needed files as ONE gzipped tar stream (bpsh stdin
+#                is byte-clean, so no base64) and the server extracts in bulk.
+#                gzip keeps tiny syncs tiny -- a plain tar pads to a 10 KiB
+#                blocking-factor minimum regardless of content.
+# Same 4-file scenario as Case 6 (1 identical, 1 changed, 2 new).  Asserts:
+#   (a) the remote dir becomes identical to the local dir,
+#   (b) only the changed + new files are sent (the identical one is skipped),
+#   (c) exactly two bpsh command exchanges (roundtrips) are used.
+# ----------------------------------------------------------------------
+echo
+echo "Case 7: two-roundtrip SHA-manifest sync over bpsh (DTN-suitable)"
+CASE7_FAIL=0
+L7=/tmp/bpsh-sync2-local.$$
+R7=/tmp/bpsh-sync2-remote.$$
+MAN7=/tmp/bpsh-sync2-man.$$
+rm -rf "$L7" "$R7"; mkdir -p "$L7" "$R7"
+
+printf 'identical contents\n'      > "$L7/same.txt"
+printf 'NEW version of the file\n' > "$L7/changed.txt"
+printf 'a brand-new file\n'        > "$L7/added.txt"
+printf 'another brand-new file\n'  > "$L7/added2.txt"
+printf 'identical contents\n'      > "$R7/same.txt"
+printf 'OLD version of the file\n' > "$R7/changed.txt"
+
+# BP bundle counters from a single bpstats dump (consistent xmt+rcv pair).
+bpsnap() { bpstats >/dev/null 2>&1; sleep 1; tail -40 ion.log; }
+bpval()  { echo "$1" | grep "\[x\] $2 " | tail -1 | sed -E 's/.*\(\+\) ([0-9]+) ([0-9]+).*/\1 \2/'; }
+
+RTRIPS=0
+S=$(bpsnap); read XC0 XB0 <<< "$(bpval "$S" xmt)"; read RC0 RB0 <<< "$(bpval "$S" rcv)"
+
+# --- Roundtrip 1: pull the remote per-file SHA-256 manifest ---
+RTRIPS=$((RTRIPS + 1))
+bpsh -h ipn:1.22 -l ipn:1.514 -c \
+"cd $R7 && for f in *; do [ -f \"\$f\" ] && echo \"\$f \$(sha256sum \"\$f\" | cut -c1-64)\"; done" \
+> "$MAN7" 2>/dev/null
+
+# Diff locally: a file missing remotely or with a different hash must be sent.
+TO_SEND=
+for f in same.txt changed.txt added.txt added2.txt; do
+	lsha=$(sha256sum "$L7/$f" | cut -c1-64)
+	rsha=$(awk -v n="$f" '$1==n{print $2}' "$MAN7")
+	[ "$lsha" != "$rsha" ] && TO_SEND="$TO_SEND $f"
+done
+TO_SEND=$(echo $TO_SEND)
+
+# --- Roundtrip 2: ship all needed files as one gzipped tar; server extracts ---
+RTRIPS=$((RTRIPS + 1))
+tar -C "$L7" -czf - $TO_SEND | \
+	bpsh -h ipn:1.22 -l ipn:1.515 -c "tar -xzf - -C $R7" \
+	> /dev/null 2>&1
+sleep 1
+
+S=$(bpsnap); read XC1 XB1 <<< "$(bpval "$S" xmt)"; read RC1 RB1 <<< "$(bpval "$S" rcv)"
+echo "  bundles over bpsh for this sync: sent=$((XC1 - XC0)) recv=$((RC1 - RC0))" \
+     "(bytes tx=$((XB1 - XB0)) rx=$((RB1 - RB0)))"
+
+# (a) remote dir identical to local dir.
+if ! diff -r "$L7" "$R7" >/dev/null 2>&1; then
+	echo "  remote dir not identical to local after sync"
+	diff -r "$L7" "$R7"
+	CASE7_FAIL=1
+fi
+# (b) only the changed + new files were sent; the identical one was skipped.
+case " $TO_SEND " in
+	*" same.txt "*) echo "  identical same.txt was sent"; CASE7_FAIL=1 ;;
+esac
+for f in changed.txt added.txt added2.txt; do
+	case " $TO_SEND " in
+		*" $f "*) ;;
+		*) echo "  $f not sent"; CASE7_FAIL=1 ;;
+	esac
+done
+# (c) exactly two roundtrips (request/response exchanges) were used.
+if [ "$RTRIPS" -ne 2 ]; then
+	echo "  expected exactly 2 roundtrips, used $RTRIPS"
+	CASE7_FAIL=1
+fi
+
+rm -rf "$L7" "$R7" "$MAN7"
+
+if [ $CASE7_FAIL -eq 0 ]; then
+	echo "  Case 7 PASS"
+else
+	echo "  Case 7 FAIL"
+	FAIL=1
+fi
+
+# ----------------------------------------------------------------------
 # Teardown
 # ----------------------------------------------------------------------
 echo

--- a/tests/bpsh-loopback/dotest
+++ b/tests/bpsh-loopback/dotest
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+trap 'killm f >/dev/null 2>&1' EXIT
+#
+# Loopback test for bpsh / bpshd (issue #83).
+# Validates Phase 2 features:
+#   - persistent shell across REQs (cd, env var stick)
+#   - separate STDOUT and STDERR delivery
+#   - exit-code propagation observable via $?
+#   - INIT replaces any prior session for the same source EID
+#
+
+CONFIGFILES="./config/host1.rc"
+
+echo "########################################"
+echo
+pwd | sed "s/\/.*\///" | xargs echo "NAME: "
+echo
+echo "PURPOSE: bpsh / bpshd phase 2 — persistent shell, stderr split,"
+echo "         exit-code propagation, session replacement on INIT."
+echo
+echo "CONFIG: single-node loopback"
+echo
+for N in $CONFIGFILES; do
+	echo "$N:"
+	cat "$N"
+	echo "# EOF"
+	echo
+done
+echo "########################################"
+
+FAIL=0
+
+./cleanup
+sleep 1
+
+echo "Starting ION..."
+ionstart -I config/host1.rc
+
+echo "Starting bpshd on ipn:1.22..."
+bpshd ipn:1.22 > bpshd.log 2>&1 &
+BPSHD_PID=$!
+echo "$BPSHD_PID" > bpshd.pid
+sleep 2
+if ! kill -0 "$BPSHD_PID" 2>/dev/null; then
+	echo "ERROR: bpshd died at startup"
+	cat bpshd.log
+	ionstop
+	exit 1
+fi
+
+# use the below to run your own bpsh client against the local running bpshd
+# sleep 10000
+
+# ----------------------------------------------------------------------
+# Case 1: cd / env-var persistence + stderr split + exit-code surfacing
+# ----------------------------------------------------------------------
+echo
+echo "Case 1: cd, exports, stderr split, exit-code propagation"
+{
+	echo "cd /tmp"
+	echo "pwd"
+	echo "export BPSH_TESTVAR=hello"
+	echo "echo \"var=\$BPSH_TESTVAR\""
+	echo "echo to-stderr-line >&2"
+	echo "false"
+	echo "echo \"rc=\$?\""
+} | bpsh ipn:1.500 ipn:1.22 > out.case1 2> err.case1
+
+echo "go for it!"
+sleep 3
+
+CASE1_FAIL=0
+grep -qx "/tmp"          out.case1 || { echo "  cd not persisted";           CASE1_FAIL=1; }
+grep -qx "var=hello"     out.case1 || { echo "  export not persisted";       CASE1_FAIL=1; }
+grep -qx "rc=1"          out.case1 || { echo "  exit-code not propagated";   CASE1_FAIL=1; }
+grep -qx "to-stderr-line" err.case1 || { echo "  stderr not separated";      CASE1_FAIL=1; }
+grep -q  "to-stderr-line" out.case1 && { echo "  stderr leaked into stdout"; CASE1_FAIL=1; }
+
+if [ $CASE1_FAIL -eq 0 ]; then
+	echo "  Case 1 PASS"
+else
+	echo "  Case 1 FAIL"
+	echo "  --- out.case1 ---"; cat out.case1; echo "  --- err.case1 ---"; cat err.case1
+	FAIL=1
+fi
+
+# ----------------------------------------------------------------------
+# Case 2: a fresh bpsh instance starts a fresh session — /tmp must NOT
+# be inherited from Case 1 (server-side cwd is bpshd's startup dir).
+# ----------------------------------------------------------------------
+echo
+echo "Case 2: fresh INIT replaces prior session (no cd carryover)"
+{
+	echo "pwd"
+	echo "echo \"var=\${BPSH_TESTVAR-unset}\""
+} | bpsh ipn:1.501 ipn:1.22 > out.case2 2> err.case2
+
+CASE2_FAIL=0
+if grep -qx "/tmp" out.case2; then
+	echo "  prior session's cd leaked into new INIT"
+	CASE2_FAIL=1
+fi
+grep -qx "var=unset" out.case2 || { echo "  prior session's env leaked"; CASE2_FAIL=1; }
+
+if [ $CASE2_FAIL -eq 0 ]; then
+	echo "  Case 2 PASS"
+else
+	echo "  Case 2 FAIL"
+	echo "  --- out.case2 ---"; cat out.case2; echo "  --- err.case2 ---"; cat err.case2
+	FAIL=1
+fi
+
+# ----------------------------------------------------------------------
+# Case 4: streaming — produce > 64 KB output and verify (a) it all
+# arrives intact, (b) it didn't all come in one final bundle (i.e. the
+# server flushed mid-command).  We probe (b) indirectly: emit a marker
+# line at known byte offsets and verify the end of stdout is reached
+# faster than a non-streaming server would manage with a sleep at end.
+# ----------------------------------------------------------------------
+echo
+echo "Case 4: streaming flush of large output"
+{
+	# 80 KB of deterministic output, then a marker, then sleep so a
+	# non-streaming server would block here.  A streaming server
+	# emits all 80 KB before sleeping.
+	echo "yes 'streaming-line' | head -n 4096"
+	echo "echo END_MARKER"
+	echo "sleep 1"
+	echo "echo POST_SLEEP"
+} | bpsh ipn:1.503 ipn:1.22 > out.case4 2> err.case4
+
+CASE4_FAIL=0
+LINES=$(grep -c "^streaming-line$" out.case4)
+if [ "$LINES" != "4096" ]; then
+	echo "  expected 4096 streaming-line, got $LINES"
+	CASE4_FAIL=1
+fi
+grep -qx "END_MARKER" out.case4 || { echo "  END_MARKER missing"; CASE4_FAIL=1; }
+grep -qx "POST_SLEEP" out.case4 || { echo "  POST_SLEEP missing"; CASE4_FAIL=1; }
+
+# Streaming evidence: with 80 KB of output and a 200 ms flush window,
+# at least 2 STDOUT bundles should have crossed the wire.  Probe it via
+# bpshd.log via dlv counts -- but that's brittle, skip and trust the
+# byte-count check.
+
+if [ $CASE4_FAIL -eq 0 ]; then
+	echo "  Case 4 PASS"
+else
+	echo "  Case 4 FAIL"
+	echo "  --- out.case4 (head/tail) ---"
+	head -3 out.case4; echo "..."; tail -3 out.case4
+	echo "  --- err.case4 ---"; cat err.case4
+	FAIL=1
+fi
+
+# ----------------------------------------------------------------------
+# Case 3: same-EID re-INIT discards the previous session's state.
+# Run twice with the SAME local EID; second run must NOT see /tmp.
+# ----------------------------------------------------------------------
+echo
+echo "Case 3: same-EID re-INIT wipes prior shell"
+echo "cd /tmp"               | bpsh ipn:1.502 ipn:1.22 > /dev/null 2>&1
+echo "pwd"                   | bpsh ipn:1.502 ipn:1.22 > out.case3 2> err.case3
+
+# ----------------------------------------------------------------------
+# Case 5: -c one-shot mode + stdin forwarding via STDIN_CHUNK / EOF.
+# Pipes data into bpsh -c "tee /tmp/X" and verifies (a) the file on
+# the server side matches the input, (b) bpsh's exit code is the
+# remote command's exit code, (c) stdout from tee echoes the input.
+# ----------------------------------------------------------------------
+echo
+echo "Case 5: -c one-shot mode with stdin forwarding"
+TEEFILE=/tmp/bpsh-stdin-test.$$
+rm -f "$TEEFILE"
+INPUT="hello bpsh"$'\n'"second line"
+echo -n "$INPUT" | bpsh -h ipn:1.22 -l ipn:1.504 -c "tee $TEEFILE" > out.case5 2> err.case5
+RC5=$?
+
+CASE5_FAIL=0
+if [ "$RC5" != "0" ]; then
+	echo "  bpsh -c exit code wrong: $RC5"
+	CASE5_FAIL=1
+fi
+if [ ! -f "$TEEFILE" ]; then
+	echo "  remote tee did not create $TEEFILE"
+	CASE5_FAIL=1
+elif [ "$(cat "$TEEFILE")" != "$INPUT" ]; then
+	echo "  $TEEFILE contents differ from input"
+	echo "  --- expected ---"; echo -n "$INPUT"; echo
+	echo "  --- got ---"; cat "$TEEFILE"; echo
+	CASE5_FAIL=1
+fi
+if [ "$(cat out.case5)" != "$INPUT" ]; then
+	echo "  bpsh stdout (tee echo) differs from input"
+	echo "  --- expected ---"; echo -n "$INPUT"; echo
+	echo "  --- got ---"; cat out.case5; echo
+	CASE5_FAIL=1
+fi
+
+# Verify -c propagates non-zero exit codes too.
+echo "anything" | bpsh -h ipn:1.22 -l ipn:1.505 -c "exit 9" > /dev/null 2>&1
+RC5b=$?
+if [ "$RC5b" != "9" ]; then
+	echo "  bpsh -c did not propagate exit 9 (got $RC5b)"
+	CASE5_FAIL=1
+fi
+
+rm -f "$TEEFILE"
+
+if [ $CASE5_FAIL -eq 0 ]; then
+	echo "  Case 5 PASS"
+else
+	echo "  Case 5 FAIL"
+	FAIL=1
+fi
+
+if grep -qx "/tmp" out.case3; then
+	echo "  same-EID re-INIT did not wipe state"
+	echo "  --- out.case3 ---"; cat out.case3
+	FAIL=1
+else
+	echo "  Case 3 PASS"
+fi
+
+# ----------------------------------------------------------------------
+# Teardown
+# ----------------------------------------------------------------------
+echo
+echo "Stopping bpshd..."
+kill "$BPSHD_PID" 2>/dev/null
+wait "$BPSHD_PID" 2>/dev/null
+
+echo "Stopping ION..."
+ionstop
+
+exit $FAIL


### PR DESCRIPTION
Add bpsh (client) and bpshd (daemon): a remote shell that executes commands on a remote node over BPv7, in the spirit of ssh but built for store-and-forward DTN links.  Implements #83.

Protocol (bpsh_proto):
  - CBOR-framed messages carried in bundle payloads: INIT / INIT_ACK, REQ, STDIN_CHUNK / STDIN_EOF, STDOUT / STDERR, CWD, EXIT, ERROR, EXIT_SESSION.
  - Per-session id and monotonic sequence numbers; the client delivers frames in order and treats ERROR as out-of-band.
  - Shared encode/decode, send, receive and attach helpers.

Daemon (bpshd, bpshd_session):
  - One persistent /bin/sh per client, keyed by source EID, so cd, environment and shell functions persist across commands.
  - Split into a per-session object (the shell, its pipes and command execution) and a manager (session table, deferred-bundle queue, receive/dispatch loop).
  - The exit status and the command boundary travel out-of-band on a control fd: each command runs as "{ cmd ; } <&3 4>&-; echo $? >&4" while stdout/stderr stream verbatim, and the daemon finishes the command when it reads the rc.  No in-band sentinels, no holdback.
  - stdin forwarding to the remote command; ReqAttendant-based flow control so large output (e.g. du over a big tree) blocks for ZCO space instead of being dropped; a per-command wall-clock timeout (BPSHD_CMD_TIMEOUT, default 300s) and output cap with process-group teardown; and recovery: a fresh INIT aborts a stalled command and starts a new session.

Client (bpsh):
  - Interactive REPL and one-shot mode (-c, exits with the remote rc and forwards non-TTY stdin).
  - Raw-mode line editing (left/right/home/end/delete), command history on the up/down arrows plus a "history" builtin, and a prompt that shows the remote shell's working directory.
  - "exit" closes the session and leaves the REPL cleanly; SIGSEGV / SIGBUS are reported as a clean "lost the local ION node" exit rather than a core dump.

Adds a loopback regression test (tests/bpsh-loopback) and Makefile wiring.