### PR TITLE
Use the proper typedefs to avoid pointer truncation

### DIFF
--- a/ici/test/smrbtsh.c
+++ b/ici/test/smrbtsh.c
@@ -69,8 +69,8 @@ static int	compareNodes(PsmPartition partition, PsmAddress nodeData,
 	/* Parameter intentionally unused. */
 	(void)partition;
 
-	unsigned long nd = (unsigned long) nodeData;
-	unsigned long db = *((unsigned long *) dataBuffer);
+	uaddr nd = (uaddr) nodeData;
+	uaddr db = *((uaddr *) dataBuffer);
 	if (nd < db) return -1;
 	if (nd > db) return 1;
 	return 0;


### PR DESCRIPTION
As per https://github.com/nasa-jpl/ION-DTN/issues/71.

The concern here is that we are casting a `PsmAddress` to a `unsigned long`, whereas on some platforms, this value may in fact be a `unsigned long long` type, leading to pointer truncation.

While there is benefit in considering a migration to `stdint.h` types, there's concerns about backward compatibility with older VxWorks releases (that lack `stdint.h`) and the possibility of introducing bugs in the transition.

This minimally adjusts the casts to use the `uaddr` data type to avoid the truncation issue.  Not handled here is a potential unaligned value access, but so long as the pointers are properly aligned, this should not be a problem.