### PR TITLE
ionadmin: add 'i clock' command to report node clock parameters

### DIFF
--- a/ici/doc/pod5/ionrc.pod
+++ b/ici/doc/pod5/ionrc.pod
@@ -197,6 +197,15 @@ SDR heap and working memory.  Each pool is reported as either "OK" or
 "BREACHED" depending on whether free space is above or below the configured
 threshold.
 
+=item B<i clock>
+
+This command prints the node's current clock parameters as a single line:
+B<utcdelta> (as set by B<m utcdelta>), B<clockerr> (as set by
+B<m clockerr>), B<clocksync> (the boolean set by B<m clocksync>), and
+B<ctime>, ION's current corrected time (system time less B<utcdelta>),
+and B<systime>, the uncorrected system time.  Both are Unix epoch values
+with microsecond precision (I<seconds>.I<microseconds>).
+
 =item B<l contact>
 
 This command lists all contacts in the contact plan for the selected region.

--- a/ici/utils/ionadmin.c
+++ b/ici/utils/ionadmin.c
@@ -163,6 +163,7 @@ in bytes per second> [confidence in occurrence]");
 	PUTS("\t   {d|i} contact <from time> <from node> <to node>");
 	PUTS("\t   {d|i} range <from time> <from node> <to node>");
 	PUTS("\t   i memprotect");
+	PUTS("\t   i clock");
 	PUTS("\t\tTo delete all contacts or ranges for some pair of nodes,");
 	PUTS("\t\tuse '*' as <from time>.");
 	PUTS("\tl\tList");
@@ -612,6 +613,28 @@ static void	executeInfo(int tokenCount, char **tokens)
 			wmPctFree,
 			(wmPct > 0 && wmPctFree < wmPct)
 				? "BREACHED" : "OK");
+		printText(buffer);
+		return;
+	}
+
+	if (strcmp(tokens[1], "clock") == 0)
+	{
+		Object		iondbObj = getIonDbObject();
+		IonDB		iondb;
+		struct timeval	tv;
+
+		CHKVOID(sdr_begin_xn(sdr));
+		sdr_read(sdr, (char *) &iondb, iondbObj, sizeof(IonDB));
+		sdr_exit_xn(sdr);
+		getCurrentTime(&tv);
+		isprintf(buffer, sizeof buffer,
+			"utcdelta %d clockerr %d clocksync %d "
+			"ctime %ld.%06ld systime %ld.%06ld",
+			iondb.deltaFromUTC, iondb.maxClockError,
+			(int) iondb.clockIsSynchronized,
+			(long) (tv.tv_sec - iondb.deltaFromUTC),
+			(long) tv.tv_usec,
+			(long) tv.tv_sec, (long) tv.tv_usec);
 		printText(buffer);
 		return;
 	}


### PR DESCRIPTION
Print the node's current clock configuration on a single line: utcdelta, clockerr, clocksync, ctime and systime.
Document the new command in ionrc.pod.